### PR TITLE
Put all hector code in the Hector:: namespace.

### DIFF
--- a/headers/components/bc_component.hpp
+++ b/headers/components/bc_component.hpp
@@ -13,6 +13,8 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Black carbon model component.
  *
@@ -60,5 +62,7 @@ private:
     Core *core;
     double oldDate;
 };
+
+}
 
 #endif // BLACK_CARBON_COMPONENT_H

--- a/headers/components/ch4_component.hpp
+++ b/headers/components/ch4_component.hpp
@@ -14,6 +14,8 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Methane model component.
  *
@@ -62,6 +64,8 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif // CH4_COMPONENT_H
 

--- a/headers/components/dummy_model_component.hpp
+++ b/headers/components/dummy_model_component.hpp
@@ -13,6 +13,8 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief A Dummy model component.
  *
@@ -70,5 +72,7 @@ private:
     // logger
     Logger logger;
 };
+
+}
 
 #endif // DUMMY_MODEL_COMPONENT_H

--- a/headers/components/forcing_component.hpp
+++ b/headers/components/forcing_component.hpp
@@ -20,6 +20,8 @@
 #include "data/unitval.hpp"
 #include "models/carbon-cycle-model.hpp"
 
+namespace Hector {
+  
 // Need to forward declare the components which depend on each other
 class SimpleNbox;
 class HalocarbonComponent;
@@ -78,5 +80,7 @@ private:
     double oldDate;
     Logger logger;          //! Logger
 };
+
+}
 
 #endif // FORCING_COMPONENT_H

--- a/headers/components/halocarbon_component.hpp
+++ b/headers/components/halocarbon_component.hpp
@@ -13,6 +13,8 @@
 #include "data/unitval.hpp"
 #include "imodel_component.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Model component for a halocarbon.
  *
@@ -82,5 +84,7 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif // HALOCARBON_COMPONENT_HPP

--- a/headers/components/imodel_component.hpp
+++ b/headers/components/imodel_component.hpp
@@ -15,6 +15,8 @@
 #include "data/message_data.hpp"
 #include "h_exception.hpp"
 
+namespace Hector {
+  
 class Core;
 class DependencyFinder;
 
@@ -148,6 +150,8 @@ private:
 
 // Inline methods
 IModelComponent::~IModelComponent() {
+}
+
 }
 
 #endif // IMODEL_COMPONENT_H

--- a/headers/components/n2o_component.hpp
+++ b/headers/components/n2o_component.hpp
@@ -13,6 +13,8 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Nitrous oxide model component.
  *
@@ -60,5 +62,7 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif // N2O_COMPONENT_H

--- a/headers/components/o3_component.hpp
+++ b/headers/components/o3_component.hpp
@@ -13,6 +13,7 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
 //------------------------------------------------------------------------------
 /*! \brief Ozone model component.
  *
@@ -67,5 +68,7 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif // OZONE_COMPONENT_H

--- a/headers/components/oc_component.hpp
+++ b/headers/components/oc_component.hpp
@@ -13,6 +13,8 @@
 #include "data/tseries.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Organic carbon model component.
  *
@@ -60,5 +62,7 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif // ORGANIC_CARBON_COMPONENT_H

--- a/headers/components/ocean_component.hpp
+++ b/headers/components/ocean_component.hpp
@@ -22,6 +22,8 @@
 #define OCEAN_TSR_TRIGGER1      0.1     //!< trigger1 to reduce timestep:
                                         //!< absolute diff between successive annual fluxes (Pg C)
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Ocean model component.
  *
@@ -114,5 +116,7 @@ private:
     //! logger
     Logger logger;
 };
+
+}
 
 #endif // OCEAN_COMPONENT_H

--- a/headers/components/onelineocean_component.hpp
+++ b/headers/components/onelineocean_component.hpp
@@ -12,6 +12,8 @@
 #include "core/logger.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief A one-line ocean model component.
  *
@@ -59,5 +61,7 @@ private:
     //! logger
     Logger logger;
 };
+
+}
 
 #endif // ONELINEOCEAN_COMPONENT_H

--- a/headers/components/slr_component.hpp
+++ b/headers/components/slr_component.hpp
@@ -16,7 +16,8 @@
 // Need to forward declare the components which depend on each other
 #include "components/temperature_component.hpp"
 
-
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief The sea level rise component.
  *
@@ -75,5 +76,7 @@ private:
     //! logger
     Logger logger;
 };
+
+}
 
 #endif // SLR_COMPONENT_H

--- a/headers/components/so2_component.hpp
+++ b/headers/components/so2_component.hpp
@@ -14,6 +14,7 @@
 #include "data/unitval.hpp"
 
 
+namespace Hector {
 //------------------------------------------------------------------------------
 /*! \brief Sulfur model component.
  *
@@ -67,5 +68,7 @@ private:
 	Core *core;
     double oldDate;
 };
+
+}
 
 #endif  // SULFUR_COMPONENT_H

--- a/headers/components/temperature_component.hpp
+++ b/headers/components/temperature_component.hpp
@@ -14,6 +14,8 @@
 #include "data/unitval.hpp"
 
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Temperature model component.
  *
@@ -63,5 +65,7 @@ private:
     //! logger
     Logger logger;
 };
+
+}
 
 #endif // TEMP_COMPONENT_H

--- a/headers/core/carbon-cycle-solver.hpp
+++ b/headers/core/carbon-cycle-solver.hpp
@@ -9,7 +9,6 @@
  */
 
 #include <string>
-//#include <gsl/gsl_odeiv.h>
 #include <gsl/gsl_odeiv2.h>
 
 #include "core/logger.hpp"
@@ -18,6 +17,8 @@
 
 #define MAX_CARBON_MODEL_RETRIES 8
 
+namespace Hector {
+  
 /*! \brief The carbon cycle solver component
  *
  * The strategy in this solver is to write the carbon cycle as
@@ -120,5 +121,7 @@ private:
     //! Logger for solver
     Logger logger;
 };
+
+}
 
 #endif

--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -17,6 +17,8 @@
 #include "h_exception.hpp"
 #include "ivisitable.hpp"
 
+namespace Hector {
+  
 class unitval;
 class message_data;
 class IModelComponent;
@@ -170,5 +172,7 @@ private:
     // Some helpful typedefs to clean up syntax
     typedef std::vector<AVisitor*>::iterator VisitorIterator;
 };
+
+}
 
 #endif // CORE_H

--- a/headers/core/dependency_finder.hpp
+++ b/headers/core/dependency_finder.hpp
@@ -19,6 +19,8 @@
 
 #include "h_exception.hpp"
 
+namespace Hector {
+
 /*! 
 * \brief This class calculates an ordering of named objects through a scheduling
 *        algorithm based on supplied dependencies.
@@ -69,5 +71,7 @@ private:
     //! The correctly ordered list of sectors.
     std::vector<std::string> mOrdering;
 };
+
+}
 
 #endif // _DEPENDENCY_FINDER_H_

--- a/headers/core/ivisitable.hpp
+++ b/headers/core/ivisitable.hpp
@@ -8,6 +8,8 @@
  *
  */
 
+namespace Hector {
+  
 class AVisitor;
 
 //------------------------------------------------------------------------------
@@ -29,6 +31,8 @@ public:
 
 // Inline methods
 IVisitable::~IVisitable() {
+}
+
 }
 
 #endif // IVISITABLE_H

--- a/headers/core/logger.hpp
+++ b/headers/core/logger.hpp
@@ -16,7 +16,8 @@
 #define LOG_DIRECTORY "logs/"
 #define LOG_EXTENSION ".log"
 
-
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Logger class
  *
@@ -93,6 +94,8 @@ public:
     
     static Logger& getGlobalLogger();
 };
+
+}
 
 /*!
  * \brief Some systems define the function name macro differently, so double

--- a/headers/data/h_interpolator.hpp
+++ b/headers/data/h_interpolator.hpp
@@ -8,6 +8,7 @@
  *
  */
 
+namespace Hector {
 
 enum interpolation_methods { DEFAULT, LINEAR, SPLINE_FORSYTHE };
 
@@ -104,6 +105,7 @@ inline void h_interpolator::locate(double x, int &iprev, int &inext) const
     ilast = iprev;
     
 }
-                
+
+}
 
 #endif

--- a/headers/data/message_data.hpp
+++ b/headers/data/message_data.hpp
@@ -13,6 +13,8 @@
 #include "core/core.hpp"
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 /*! \brief Message data type.
  *
  *  Contains fields for all the types of data that may be passed around with
@@ -51,5 +53,7 @@ struct message_data {
     //! A string characterizing the units of value (if applicable).
     std::string units_str;
 };
+
+}
 
 #endif

--- a/headers/data/tseries.hpp
+++ b/headers/data/tseries.hpp
@@ -16,6 +16,8 @@
 #include "data/unitval.hpp"
 #include "h_exception.hpp"
 
+namespace Hector {
+  
 /*! \brief Time series data type.
  *
  *  Currently implemented as an STL map.
@@ -287,6 +289,8 @@ double tseries<T_data>::last() const {
 template <class T_data>
 int tseries<T_data>::size() const {
     return mapdata.size();
+}
+
 }
 
 #endif

--- a/headers/data/unitval.hpp
+++ b/headers/data/unitval.hpp
@@ -11,6 +11,8 @@
 #include "core/logger.hpp"
 #include "h_exception.hpp"
 
+namespace Hector {
+  
 /*! \brief A simple value-and-units capability.
  *
  *  What was wrong with using the Boost Units (BU) package?
@@ -281,6 +283,8 @@ inline
 std::ostream& operator<<( std::ostream &out, unitval &x ) {
     out << x.value( x.units() ) << " " << x.unitsName();
     return out;
+}
+
 }
 
 #endif

--- a/headers/input/csv_table_reader.hpp
+++ b/headers/input/csv_table_reader.hpp
@@ -12,6 +12,8 @@
 
 #include "h_exception.hpp"
 
+namespace Hector {
+
 class Core;
 
 /*! \brief A class responsible for reading time series data from a CSV file and
@@ -52,5 +54,7 @@ private:
     std::string csv_getline();
 
 };
+
+}
 
 #endif // CSV_TABLE_READER_H

--- a/headers/input/h_reader.hpp
+++ b/headers/input/h_reader.hpp
@@ -7,8 +7,13 @@
  *
  */
 
+#ifndef H_READER_HPP_
+#define H_READER_HPP_
+
 #include "inih/INIReader.h"
 #include "h_exception.hpp"
+
+namespace Hector {
 
 enum readertype_t { INI_style, table_style };
 
@@ -27,3 +32,7 @@ private:
     INIReader* reader;
     std::string filename;
 };
+
+}
+
+#endif

--- a/headers/input/ini_to_core_reader.hpp
+++ b/headers/input/ini_to_core_reader.hpp
@@ -10,6 +10,8 @@
 
 #include "h_exception.hpp"
 
+namespace Hector {
+
 class Core;
 
 /*! \brief An adaptor class to send data read from an INI file directly to the
@@ -47,5 +49,7 @@ class INIToCoreReader {
                                      const StringIter endBracket,
                                      const StringIter strEnd );
 };
+
+}
 
 #endif // INI_TO_CORE_READER_H

--- a/headers/input/inih/INIReader.h
+++ b/headers/input/inih/INIReader.h
@@ -11,6 +11,8 @@
 #include <map>
 #include <string>
 
+namespace Hector {
+  
 // Read an INI file into easy-to-access name/value pairs. (Note that I've gone
 // for simplicity here rather than speed, but it should be pretty decent.)
 class INIReader
@@ -39,5 +41,7 @@ private:
     static int ValueHandler(void* user, const char* section, const char* name,
                             const char* value);
 };
+
+}
 
 #endif  // __INIREADER_H__

--- a/headers/models/carbon-cycle-model.hpp
+++ b/headers/models/carbon-cycle-model.hpp
@@ -26,6 +26,7 @@
 // need to stash C values and re-try reaching next timestep
 #define CARBON_CYCLE_RETRY 1234
 
+namespace Hector {
 
 /*! \brief Carbon cycle model class
  *
@@ -110,5 +111,7 @@ protected:
     //! Pointers to the core
     Core *core;
 };
+
+}
 
 #endif

--- a/headers/models/ocean_csys.hpp
+++ b/headers/models/ocean_csys.hpp
@@ -12,6 +12,8 @@
 
 #include "data/unitval.hpp"
 
+namespace Hector {
+  
 class oceancsys
 {
     /*! /brief  Ocean Carbon Chemistry
@@ -72,4 +74,8 @@ private:
     Logger* logger;
 
 };
+
+}
+
 #endif
+  

--- a/headers/models/oceanbox.hpp
+++ b/headers/models/oceanbox.hpp
@@ -25,6 +25,8 @@
 
 #define MEAN_GLOBAL_TEMP 15
 
+namespace Hector {
+
 class oceanbox {
     /*! /brief  An ocean box
      *
@@ -95,4 +97,7 @@ public:
 	// logger
     Logger* logger;
 };
+
+}
+
 #endif

--- a/headers/models/simpleNbox.hpp
+++ b/headers/models/simpleNbox.hpp
@@ -23,6 +23,8 @@
 #define SNBOX_PARSECHAR "."             //!< input separator between <biome> and <pool>
 #define SNBOX_DEFAULT_BIOME "global"    //!< value if no biome supplied
 
+namespace Hector {
+
 /*! \brief The simple global carbon model, not including the ocean
  *
  *  SimpleNbox tracks atmosphere (1 pool), land (3 pools), ocean (1 pool from its p.o.v.), 
@@ -139,4 +141,7 @@ private:
     CarbonCycleModel *omodel;           //!< pointer to the ocean model in use
 
 };
+
+}
+
 #endif

--- a/headers/visitors/avisitor.hpp
+++ b/headers/visitors/avisitor.hpp
@@ -8,6 +8,8 @@
  *
  */
 
+namespace Hector {
+  
 // Forward declare all visitable subclasses.
 class Core;
 class DummyModelComponent;
@@ -65,6 +67,8 @@ public:
 
 // Inline methods
 AVisitor::~AVisitor() {
+}
+
 }
 
 #endif // AVISITOR_H

--- a/headers/visitors/csv_output_visitor.hpp
+++ b/headers/visitors/csv_output_visitor.hpp
@@ -16,6 +16,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 /*! \brief A visitor which will report a few results at each model period.
  */
 class CSVOutputVisitor : public AVisitor {
@@ -36,5 +38,7 @@ private:
     
 #define DELIMITER ","
 };
+
+}
 
 #endif // CSV_OUTPUT_VISITOR_H

--- a/headers/visitors/csv_outputstream_visitor.hpp
+++ b/headers/visitors/csv_outputstream_visitor.hpp
@@ -14,6 +14,8 @@
 
 #define DELIMITER ","
 
+namespace Hector {
+  
 /*! \brief A visitor which will report all results at each model period.
  */
 class CSVOutputStreamVisitor : public AVisitor {
@@ -59,5 +61,7 @@ private:
     //! pointers to other components and stuff
     Core*             core;
 };
+
+}
 
 #endif // CSV_OUTPUTSTREAM_VISITOR_H

--- a/headers/visitors/ini_restart_visitor.hpp
+++ b/headers/visitors/ini_restart_visitor.hpp
@@ -12,6 +12,8 @@
 
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 /*! \brief A visitor which will attempt to gather all information to restart the
  *         model and write them in an INI style restart file.
  *  \todo This class strips all units from the output variables since unit input
@@ -37,5 +39,7 @@ private:
     //! sophisticated in the future.
     const double restartDate;
 };
+
+}
 
 #endif // INI_RESTART_VISITOR_H

--- a/source/components/bc_component.cpp
+++ b/source/components/bc_component.cpp
@@ -11,6 +11,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -133,4 +135,6 @@ void BlackCarbonComponent::shutDown() {
 // documentation is inherited
 void BlackCarbonComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/ch4_component.cpp
+++ b/source/components/ch4_component.cpp
@@ -12,6 +12,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -141,4 +143,6 @@ void CH4Component::shutDown() {
 // documentation is inherited
 void CH4Component::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/dummy_model_component.cpp
+++ b/source/components/dummy_model_component.cpp
@@ -13,6 +13,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -168,4 +170,6 @@ void DummyModelComponent::shutDown() {
 // documentation is inherited
 void DummyModelComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/forcing_component.cpp
+++ b/source/components/forcing_component.cpp
@@ -16,6 +16,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -370,4 +372,6 @@ void ForcingComponent::shutDown() {
 // documentation is inherited
 void ForcingComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/halocarbon_component.cpp
+++ b/source/components/halocarbon_component.cpp
@@ -13,6 +13,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 using namespace boost;
 
@@ -283,3 +285,4 @@ void HalocarbonComponent::accept( AVisitor* visitor ) {
  }
  */
 
+}

--- a/source/components/n2o_component.cpp
+++ b/source/components/n2o_component.cpp
@@ -11,6 +11,8 @@
 #include "visitors/avisitor.hpp"
 #include "h_util.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -141,3 +143,4 @@ void N2OComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
 }
 
+}

--- a/source/components/o3_component.cpp
+++ b/source/components/o3_component.cpp
@@ -13,6 +13,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -160,4 +162,6 @@ void OzoneComponent::shutDown() {
 // documentation is inherited
 void OzoneComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/oc_component.cpp
+++ b/source/components/oc_component.cpp
@@ -11,6 +11,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -134,4 +136,6 @@ void OrganicCarbonComponent::shutDown() {
 // documentation is inherited
 void OrganicCarbonComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -15,6 +15,8 @@
 #include "models/simpleNbox.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -589,4 +591,6 @@ void OceanComponent::shutDown() {
 // documentation is inherited
 void OceanComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/onelineocean_component.cpp
+++ b/source/components/onelineocean_component.cpp
@@ -11,6 +11,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -140,4 +142,6 @@ void OneLineOceanComponent::shutDown() {
 // documentation is inherited
 void OneLineOceanComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/slr_component.cpp
+++ b/source/components/slr_component.cpp
@@ -16,6 +16,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 
@@ -251,4 +253,6 @@ void slrComponent::shutDown() {
 // documentation is inherited
 void slrComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/components/so2_component.cpp
+++ b/source/components/so2_component.cpp
@@ -11,6 +11,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -165,3 +167,6 @@ void SulfurComponent::shutDown() {
 void SulfurComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
 }
+
+}
+

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -12,6 +12,8 @@
 #include "h_util.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -165,4 +167,6 @@ void TemperatureComponent::shutDown() {
 // documentation is inherited
 void TemperatureComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
+}
+
 }

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -16,7 +16,8 @@
 #include "core/carbon-cycle-solver.hpp"
 #include "visitors/avisitor.hpp"
 
-
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief Constructor
  */
@@ -390,4 +391,6 @@ bool CarbonCycleSolver::run_spinup( const int step ) throw( h_exception )
 void CarbonCycleSolver::accept( AVisitor* visitor )
 {
     visitor->visit( this );
+}
+
 }

--- a/source/core/core.cpp
+++ b/source/core/core.cpp
@@ -29,6 +29,8 @@
 #include "models/simpleNbox.hpp"
 #include "visitors/avisitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -527,4 +529,6 @@ void Core::accept( AVisitor* visitor ) {
  */
 double Core::undefinedIndex() {
     return -1;
+}
+
 }

--- a/source/core/dependency_finder.cpp
+++ b/source/core/dependency_finder.cpp
@@ -14,6 +14,8 @@
 #include "h_exception.hpp"
 #include "core/logger.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 /*!
@@ -214,3 +216,4 @@ const string& DependencyFinder::getNameFromIndex( const size_t aIndex ) const {
     return NO_NAME;
 }
 
+}

--- a/source/core/logger.cpp
+++ b/source/core/logger.cpp
@@ -10,6 +10,8 @@
 
 #include "core/logger.hpp"
 
+namespace Hector {
+
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -233,4 +235,6 @@ const char* Logger::getDateTimeStamp() {
     }
     
     return ret;
+}
+
 }

--- a/source/data/h_interpolator.cpp
+++ b/source/data/h_interpolator.cpp
@@ -12,6 +12,8 @@
 #include "h_exception.hpp"
 
 
+namespace Hector {
+  
 //-----------------------------------------------------------------------
 /*! \brief Constructor for spline class.
  *
@@ -148,4 +150,6 @@ void h_interpolator::set_method( interpolation_methods m ) {
     //TODO: log method set
     if( ndata )
         refit_data();
+}
+
 }

--- a/source/data/spline_forsythe.cpp
+++ b/source/data/spline_forsythe.cpp
@@ -8,6 +8,8 @@
 
 #include "h_exception.hpp"
 
+namespace Hector {
+
 /*  Interpolating cubic-spline function.
  Forsythe, G. E., M. A. Malcolm, and C. B. Moler. 1977. Computer Methods for
  Mathematical Computations. Prentice-Hall, Englewood Cliffs, New Jersey.
@@ -173,4 +175,6 @@ double seval_forsythe( int n, double u, double *x, double *y, double *b, double 
     /* Evaluate spline function at the argument u. */
     dx = u - x[i];
     return y[i] + dx * (b[i] + dx * (c[i] + dx * d[i]));
+}
+
 }

--- a/source/data/unitval.cpp
+++ b/source/data/unitval.cpp
@@ -13,6 +13,8 @@
 #include "data/unitval.hpp"
 #include "h_util.hpp"
 
+namespace Hector {
+  
 using namespace std;
 using namespace boost;
 
@@ -199,4 +201,6 @@ unitval unitval::parse_unitval( const string& valueStr, const string& unitsStr,
     }
     
     return unitval( value, units );
+}
+
 }

--- a/source/input/csv_table_reader.cpp
+++ b/source/input/csv_table_reader.cpp
@@ -16,6 +16,8 @@
 #include "data/message_data.hpp"
 #include "input/csv_table_reader.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -181,4 +183,6 @@ void CSVTableReader::process( Core* core, const string& componentName,
                 +castException.what() );
     }
     // h_exceptions from setData should just be passed along
+}
+
 }

--- a/source/input/h_reader.cpp
+++ b/source/input/h_reader.cpp
@@ -12,6 +12,7 @@
 #include "input/h_reader.hpp"
 #include "core/logger.hpp"
 
+namespace Hector {
 
 /*! \brief Constructor for h_reader.
  *
@@ -63,4 +64,6 @@ std::string h_reader::get_string( std::string section, std::string name, std::st
  */
 double h_reader::get_number( std::string section, std::string name, double defaultvalue ) {
     return (*reader).GetInteger( section, name, defaultvalue );
+}
+
 }

--- a/source/input/ini_to_core_reader.cpp
+++ b/source/input/ini_to_core_reader.cpp
@@ -16,6 +16,8 @@
 #include "input/inih/ini.h"
 #include "input/csv_table_reader.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -156,4 +158,6 @@ double INIToCoreReader::parseTSeriesIndex( const StringIter startBracket,
         H_THROW( "Could not convert index to double: "+dateIndexStr+", exception: "
                 +castException.what() );
     }
+}
+
 }

--- a/source/input/inih/INIReader.cpp
+++ b/source/input/inih/INIReader.cpp
@@ -21,6 +21,8 @@
 #include "input/inih/ini.h"
 #include "input/inih/INIReader.h"
 
+namespace Hector {
+  
 using std::string;
 
 INIReader::INIReader( string filename )
@@ -64,4 +66,6 @@ int INIReader::ValueHandler(void* user, const char* section, const char* name,
     INIReader* reader = (INIReader*)user;
     reader->_values[MakeKey(section, name)] = value;
     return 1;
+}
+
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -26,7 +26,8 @@ using namespace std;
  *  Starting point for wrapper, not the core.
  */
 int main (int argc, char * const argv[]) {
-	
+  using namespace Hector;
+  
 	try {
         
         // Create the global log

--- a/source/models/carbon-cycle-model.cpp
+++ b/source/models/carbon-cycle-model.cpp
@@ -8,6 +8,8 @@
 
 #include "models/carbon-cycle-model.hpp"
 
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleModel::init( Core* core ) {
@@ -46,4 +48,6 @@ void CarbonCycleModel::prepareToRun() throw(h_exception) {
 void CarbonCycleModel::shutDown() {
 	H_LOG( logger, Logger::DEBUG ) << "goodbye " << getComponentName() << std::endl;
     logger.close();
+}
+
 }

--- a/source/models/ocean_csys.cpp
+++ b/source/models/ocean_csys.cpp
@@ -23,6 +23,8 @@
 #include "h_exception.hpp"
 #include "models/ocean_csys.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -265,5 +267,4 @@ unitval oceancsys::convertToDIC( const unitval carbon ) {
 	return unitval( dic * 1e6, U_UMOL_KG );
 }
 
-
-
+}

--- a/source/models/oceanbox.cpp
+++ b/source/models/oceanbox.cpp
@@ -11,6 +11,8 @@
 
 #include "models/oceanbox.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -486,4 +488,6 @@ void oceanbox::chem_equilibrate() {
     
 	// sensitivity of the input paramaters for csys
 	//sens_parameters();
+}
+
 }

--- a/source/models/simpleNbox.cpp
+++ b/source/models/simpleNbox.cpp
@@ -14,7 +14,8 @@
 #include "models/simpleNbox.hpp"
 #include "visitors/avisitor.hpp"
 
-
+namespace Hector {
+  
 //------------------------------------------------------------------------------
 /*! \brief constructor
  */
@@ -817,4 +818,6 @@ void SimpleNbox::slowparameval( double t, const double c[] )
                 << ", tempferts=" << tempferts[ itd->first ] << std::endl;
         }
     } // for itd
+}
+
 }

--- a/source/visitors/csv_output_visitor.cpp
+++ b/source/visitors/csv_output_visitor.cpp
@@ -10,6 +10,8 @@
 
 #include "visitors/csv_output_visitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -48,4 +50,6 @@ void CSVOutputVisitor::visit( Core* c ) {
     csvFile << DELIMITER << c->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2 ).value( U_PPMV_CO2 );
     csvFile << DELIMITER << c->sendMessage( M_GETDATA, D_RF_TOTAL ).value( U_W_M2 );
     csvFile << std::endl;
+}
+
 }

--- a/source/visitors/csv_outputstream_visitor.cpp
+++ b/source/visitors/csv_outputstream_visitor.cpp
@@ -23,6 +23,8 @@
 #include "models/simpleNbox.hpp"
 #include "visitors/csv_outputstream_visitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -253,4 +255,6 @@ void CSVOutputStreamVisitor::visit( OrganicCarbonComponent* c ) {
 void CSVOutputStreamVisitor::visit( OzoneComponent* c ) {
     if( !core->outputEnabled( c->getComponentName() ) ) return;
     STREAM_MESSAGE( csvFile, c, D_ATMOSPHERIC_O3 );
+}
+
 }

--- a/source/visitors/ini_restart_visitor.cpp
+++ b/source/visitors/ini_restart_visitor.cpp
@@ -16,6 +16,8 @@
 #include "models/simpleNbox.hpp"
 #include "visitors/ini_restart_visitor.hpp"
 
+namespace Hector {
+  
 using namespace std;
 
 //------------------------------------------------------------------------------
@@ -75,4 +77,6 @@ void INIRestartVisitor::visit( ForcingComponent* c ) {
 void INIRestartVisitor::visit( HalocarbonComponent* c ) {
     restartFile << "[" << c->getComponentName() << "]" << endl;
     restartFile << D_HC_CALCDATE << "= " << restartDate << endl;
+}
+
 }


### PR DESCRIPTION
It occurred to me that when we go to include hector in GCAM, we might have some name collisions.  In particular, I believe GCAM has a 'Logger' class.  Rather than rename ours to 'HLogger' or some such, I thought it would be better to wrap all of the hector code in a namespace, so that hector's classes become Hector::Logger, Hector::Core, and so forth.  Since all of the hector code is in a single namespace, there will be no effect on internal development (i.e., you don't have to use Hector:: internally).  

Apart from solving our immediate GCAM integration problem, doing it this way also has the advantage that any other codes that want to use hector are also protected against name collisions.  That allows us to position hector as the reduced-form climate model that anybody can easily integrate into their model, whatever it may be.  If we can find a few spare hours down the line, we could even write C and Fortran APIs.  (If we're feeling really ambitious, a Python API might be really useful too, but that would be a bit more work.)
