### PR TITLE
Logger will create log directory if it is absent, or fail if unable

### DIFF
--- a/headers/core/logger.hpp
+++ b/headers/core/logger.hpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include <unistd.h>
 #include <iostream>
 #include <fstream>
 
@@ -54,6 +55,8 @@ private:
     static const std::string& logLevelToStr( const LogLevel logLevel );
     
     static const char* getDateTimeStamp();
+
+    static int chk_logdir(std::string dir);
     
     /*! \brief A customized file stream buffer to enable echoing to a console.
      *


### PR DESCRIPTION
On unix, the logger will check to see if the log directory exists and
is writable.  If it doesn't exist, it will try to create it, or die
trying.  Most of the common failure reasons are diagnosed and
reported.

On windows, the logger will attempt to create the log file and will
fail if it can't.  No attempt is made to create a missing directory,
and the error is always reported as "Unable to open log file"

Fixes #39
