### PR TITLE
Fix problem with windows builds mistakenly trying to include unistd.h et al.

### DIFF
--- a/source/core/logger.cpp
+++ b/source/core/logger.cpp
@@ -9,7 +9,7 @@
 #include <time.h>
 #include "core/logger.hpp"
 
-#if !defined(_WIN32)
+#if defined (__unix__) || defined (__MACH__)
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h> 
@@ -245,7 +245,7 @@ const char* Logger::getDateTimeStamp() {
     return ret;
 }
 
-#if !defined(_WIN32)
+#if defined (__unix__) || defined (__MACH__)
 int Logger::chk_logdir(std::string dir)
 {
     // clip trailing /, if any.  


### PR DESCRIPTION
I believe I have found a set of preprocessor macros that arranges for `unistd.h`, `sys/stat.h`, and `sys/types.h` to be included on unix and mac, but not on windows.  I have tested the fix on Linux, and everything works as expected, but having no access to a mac or windows system, I can't test there.  Please test on both windows and mac before merging this request.

Here are the behaviors expected on mac:
* The code should build successfully while including the headers mentioned above.
* If the logs directory does not exist at run time, it should be created.
* If a file (not a directory) called logs exists at run time hector should fail with the message "* Program exception: Log directory logs exists but is not a directory"
* If the logs directory exists without write permission at run time hector should fail with the message "* Program exception: Log directory logs lacks write permission."

The expected behavior on windows is:
* The code should not attempt to include any of the headers mentioned above.
* On any of the problems with the logs directory described above, hector should fail with the message "Unable to open log file".


