### PR TITLE
Enable build on OS X

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -3,7 +3,7 @@ CXXFLAGS = -g  $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
 INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR) -I$(GSLINC)
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
-LDFLAGS	 = $(CXXPROF) -L$(GSLLIB) -L. -Wl,-rpath=$(GSLLIB)
+LDFLAGS	 = $(CXXPROF) -L$(GSLLIB) -L. -Wl,-rpath $(GSLLIB)
 
 export CXXFLAGS OPTFLAGS
 


### PR DESCRIPTION
Hi,

thanks for this interesting open source project!

I tried building Hector on OS X without Xcode, just using Homebrew-installed GSL and Boost, and got

    ld: unknown option: -rpath=/usr/local/lib

 When I remove the "=" after "rpath" in the `Makefile` it compiles fine and 

    ./source/hector input/hector_rcp85.ini 

seems to run as expected.

On my Linux machine this compiles as well without the "=" so maybe this could be changed?

Used versions:

     Hector: Master (1.1)
     OS X: 10.9.5
     g++: Apple LLVM version 6.0 (clang-600.0.57)
     gsl: stable 1.16 (bottled)
     boost: stable 1.58.0 (bottled)