### PR TITLE
Make CSV paths relative to the INI file path

### DIFF
--- a/headers/input/ini_to_core_reader.hpp
+++ b/headers/input/ini_to_core_reader.hpp
@@ -51,7 +51,10 @@ class INIToCoreReader {
     private:
     //! Weak reference to a Core object that will handle parsed values
     Core* core;
-    
+
+    //! Path of the INI file
+    std::string iniFilePath;
+
     //! The exception set by value handler should an exception occur.
     //! Note that this would only be valid if valueHandler returned
     //! an error code.

--- a/input/api-example.ini
+++ b/input/api-example.ini
@@ -24,7 +24,7 @@ tu  = 49000000         ; 4.9e7 high latitude overturning, m3/s
 twi = 12500000         ; 1.25e7 warm-intermediate exchange, m3/s
 tid = 200000000        ; 2.0e8 intermediate-deep exchange, m3/s
 
-;atm_ocean_constrain=csv:input/constraints/cmip5_oceanflux.csv		; some flux record
+;atm_ocean_constrain=csv:constraints/cmip5_oceanflux.csv		; some flux record
 k = 0.2            ; ocean heat uptake efficiency  (W/m2/K)
 
 [simpleNbox]
@@ -54,18 +54,18 @@ f_lucv=0.1			; Fraction of land use change flux from vegetation
 f_lucd=0.01			; Fraction of land use change flux from detritus
 
 ; Anthropogenic contributions: direct emissions, Pg (or Gt) C/yr
-anthroEmissions=csv:input/emissions/gcam_emissions.csv	; historical emissions data only. Future emissions will be provided by GCAM
+anthroEmissions=csv:emissions/gcam_emissions.csv	; historical emissions data only. Future emissions will be provided by GCAM
 
 ; Anthropogenic contributions: land use change
-lucEmissions=csv:input/emissions/gcam_emissions.csv 
+lucEmissions=csv:emissions/gcam_emissions.csv 
 
 ; Atmospheric CO2 levels
 ; If we supply [CO2], the model will match these values
 ; Any residual between model [CO2] and model [CO2] will be put into lucEmissions
 ; If we've also supplied lucEmissions, then the residual will be eliminated by
 ; scaling the natural atmosphere fluxes (NPP, RH, ocean, etc).
-;Ca_constrain=csv:input/constraints/lawdome_co2.csv		; Law Dome CO2 record
-;Ca_constrain=csv:input/constraints/rcp45_co2ppm.csv
+;Ca_constrain=csv:constraints/lawdome_co2.csv		; Law Dome CO2 record
+;Ca_constrain=csv:constraints/rcp45_co2ppm.csv
 
 ; Initial (preindustrial) carbon fluxes
 ;boreal.npp_flux0=5.0
@@ -94,31 +94,31 @@ eps_spinup=0.001	; spinup tolerance (drift), Pg C yr-1
 [so2] 
 S0= 53841.2         ; historical sulphate from year 2000 (Ggrams)
 SN=42000			; natural sulfur emissions (Ggrams)
-;SO2_emissions = csv:input/emissions/RCP45_emissions.csv
-SO2_emissions = csv:input/emissions/gcam_emissions.csv
-;SV = csv:input/emissions/volcanic_RF.csv
+;SO2_emissions = csv:emissions/RCP45_emissions.csv
+SO2_emissions = csv:emissions/gcam_emissions.csv
+;SV = csv:emissions/volcanic_RF.csv
 
 [methane]
 M0=700.0					; preindustrial methane (ppbv) 700 ppbv IPCC, 2001 Table 6.1
 ;UC_CH4=2.746				; Tg(CH4)/ppb unit conversion between emissions and concentrations
 
-Ma = csv:input/concentrations/RCP45_ch4n2o_conc.csv
-;CH4_emissions=csv:input/emissions/RCP45_emissions.csv   ; concentration time series
+Ma = csv:concentrations/RCP45_ch4n2o_conc.csv
+;CH4_emissions=csv:emissions/RCP45_emissions.csv   ; concentration time series
 ;molarMass = 16.04       ; grams
 ;tau = 10				; lifetime in years  oucher et al 2009
 
 [ozone]
 enabled=1
 ;NOX0=0                              ;pre-industrial value
-NOX_emissions=csv:input/emissions/RCP45_emissions.csv   ; emissions time series
+NOX_emissions=csv:emissions/RCP45_emissions.csv   ; emissions time series
 
 ;CO0=0                              ;pre-industrial value
-CO_emissions=csv:input/emissions/RCP45_emissions.csv   ; emissions time series
+CO_emissions=csv:emissions/RCP45_emissions.csv   ; emissions time series
 
 ;NMVOC0=0                              ;pre-industrial value
-NMVOC_emissions=csv:input/emissions/gcam_emissions.csv   ; emissions time series
+NMVOC_emissions=csv:emissions/gcam_emissions.csv   ; emissions time series
 
-Ma = csv:input/concentrations/RCP45_ch4n2o_conc.csv
+Ma = csv:concentrations/RCP45_ch4n2o_conc.csv
 ;molarMass = 16.04       ; grams
 ;tau = 10				; lifetime in years  oucher et al 2009
 
@@ -126,26 +126,26 @@ Ma = csv:input/concentrations/RCP45_ch4n2o_conc.csv
 N0= 273.0				; preindustrial nitrous oxide, ppbv
 ;UC_N2O=4.8				; Tg(N2O)/ppb unit conversion between emissions and concentrations
 
-Na = csv:input/concentrations/RCP45_ch4n2o_conc.csv
-;N2O_emissions=csv:input/emissions/RCP45_emissions.csv   ; concentration time series
+Na = csv:concentrations/RCP45_ch4n2o_conc.csv
+;N2O_emissions=csv:emissions/RCP45_emissions.csv   ; concentration time series
 ;molarMass = 44.01     ; grams
 ;tau = 120;
 
 [forcing]
 baseyear=1750			; when to start reporting; by definition, all F=0 in this year
-;Ftot_constrain=csv:input/constraints/MAGICC_RF_8.5.csv
+;Ftot_constrain=csv:constraints/MAGICC_RF_8.5.csv
 
 [temperature]
 S=3.0 				; equilibrium climate sensitivity for 2xCO2, degC
-;tgav_constrain=csv:input/cmip5_tgav_RCP45_test.csv		; CMIP5 global temperature, RCP 4.5 
+;tgav_constrain=csv:cmip5_tgav_RCP45_test.csv		; CMIP5 global temperature, RCP 4.5 
 
 [bc]
 ; need to be in kg/yr
-BC_emissions=csv:input/emissions/gcam_emissions.csv
+BC_emissions=csv:emissions/gcam_emissions.csv
 
 [oc]
 ; need to be in kg/yr
-OC_emissions=csv:input/emissions/gcam_emissions.csv
+OC_emissions=csv:emissions/gcam_emissions.csv
 
 ; --------------------------------------------------------------------------
 ; Halocarbons in kt/yr
@@ -156,95 +156,95 @@ OC_emissions=csv:input/emissions/gcam_emissions.csv
 tau = 50000.0 		; lifetime in years
 rho = 0.00008 		; radiative efficiencies W/m2/ppt
 H0=35.0,pptv		; preindustrial concentration, pptv
-CF4_emissions = csv:input/emissions/gcam_emissions.csv
+CF4_emissions = csv:emissions/gcam_emissions.csv
 molarMass=88.0043	; grams
 
 [C2F6_halocarbon]
 tau= 10000.0
 rho= 0.00026
-C2F6_emissions = csv:input/emissions/RCP45_emissions.csv
+C2F6_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=138.01
 
 ;[C4F10_halocarbon]
 ;tau= 2600.0
 ;rho= 0.00033
-;C4F10_emissions = csv:input/emissions/RCP45_emissions.csv
+;C4F10_emissions = csv:emissions/RCP45_emissions.csv
 ;molarMass=238.0
 
 
 [HFC23_halocarbon]
 tau= 270.0
 rho= 0.00019 
-HFC23_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC23_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=70.0
 
 [HFC32_halocarbon]
 tau= 4.9
 rho= 0.00011 
-HFC32_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC32_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=52.0
 
 
 [HFC4310_halocarbon]
 tau= 15.9
 rho= 0.0004 
-HFC4310_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC4310_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=252.0
 
 [HFC125_halocarbon]
 tau= 29.0
 rho= 0.00023 
-HFC125_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC125_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=120.02
 
 [HFC134a_halocarbon]
 tau= 14.0
 rho= 0.00016
-HFC134a_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC134a_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=102.02
 
 [HFC143a_halocarbon]
 tau= 52.0
 rho= 0.00013 
-HFC143a_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC143a_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=84.04
 
 ;[HFC152a_halocarbon]
 ;tau= 1.4
 ;rho= 0.00009 
-;HFC152a_emissions = csv:input/emissions/RCP45_emissions.csv
+;HFC152a_emissions = csv:emissions/RCP45_emissions.csv
 ;molarMass=66.0
 
 [HFC227ea_halocarbon]
 tau= 34.2
 rho= 0.00026 
-HFC227ea_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC227ea_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=170.03
 
 [HFC245fa_halocarbon]
 tau= 7.6
 rho= 0.00028 
-HFC245fa_emissions = csv:input/emissions/RCP45_emissions.csv
+HFC245fa_emissions = csv:emissions/RCP45_emissions.csv
 molarMass=134.0
 
 ;[HFC236fa_halocarbon]
 ;tau= 240.0
 ;rho= 0.00028
-;HFC236fa_emissions = csv:input/emissions/RCP45_emissions.csv
+;HFC236fa_emissions = csv:emissions/RCP45_emissions.csv
 ;molarMass=152.0
 
 
 [SF6_halocarbon]
 tau= 3200.0
 rho= 0.00052
-SF6_emissions= csv:input/emissions/RCP45_emissions.csv
+SF6_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=146.06
 
 
 [CFC11_halocarbon]
 tau= 45.0
 rho= 0.00025
-CFC11_emissions= csv:input/emissions/RCP45_emissions.csv
+CFC11_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=137.35
 ;ni=3
 ;FC=1
@@ -253,7 +253,7 @@ molarMass=137.35
 [CFC12_halocarbon]
 tau= 100
 rho= 0.00032
-CFC12_emissions= csv:input/emissions/RCP45_emissions.csv
+CFC12_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=120.9
 ;ni=2
 ;FC=0.6
@@ -261,7 +261,7 @@ molarMass=120.9
 [CFC113_halocarbon]
 tau= 85.0
 rho= 0.0003
-CFC113_emissions= csv:input/emissions/RCP45_emissions.csv
+CFC113_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=187.35
 ;ni=3
 ;FC=0.75
@@ -270,7 +270,7 @@ molarMass=187.35
 [CFC114_halocarbon]
 tau= 300
 rho= 0.00031
-CFC114_emissions= csv:input/emissions/RCP45_emissions.csv
+CFC114_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=170.9
 ;ni=2
 ;FC=0.28
@@ -278,14 +278,14 @@ molarMass=170.9
 [CFC115_halocarbon]
 tau= 1700
 rho= 0.00018
-CFC115_emissions= csv:input/emissions/RCP45_emissions.csv
+CFC115_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=154.45
 
 
 [CCl4_halocarbon]
 tau= 26.0
 rho= 0.00013
-CCl4_emissions= csv:input/emissions/RCP45_emissions.csv
+CCl4_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=153.8
 ;ni=4
 ;FC=1.06
@@ -293,7 +293,7 @@ molarMass=153.8
 [CH3CCl3_halocarbon]
 tau= 5.0
 rho= 0.00006
-CH3CCl3_emissions= csv:input/emissions/RCP45_emissions.csv
+CH3CCl3_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=133.35
 ;ni=3
 ;FC=1.08
@@ -301,7 +301,7 @@ molarMass=133.35
 [halon1211_halocarbon]
 tau= 16.0
 rho= 0.00003
-halon1211_emissions= csv:input/emissions/RCP45_emissions.csv
+halon1211_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=165.35
 ;ni=1
 ;nj=1
@@ -310,7 +310,7 @@ molarMass=165.35
 [halon1301_halocarbon]
 tau= 65.0
 rho= 0.00032
-halon1301_emissions= csv:input/emissions/RCP45_emissions.csv
+halon1301_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=148.9
 ;nj=1
 ;FC=0.62
@@ -318,7 +318,7 @@ molarMass=148.9
 [halon2402_halocarbon]
 tau= 20.0
 rho= 0.00033
-halon2402_emissions= csv:input/emissions/RCP45_emissions.csv
+halon2402_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=259.8
 ;nj=2
 ;FC=1.22
@@ -326,7 +326,7 @@ molarMass=259.8
 [HCF22_halocarbon]
 tau= 12.0
 rho= 0.0002
-HCF22_emissions= csv:input/emissions/gcam_emissions.csv
+HCF22_emissions= csv:emissions/gcam_emissions.csv
 molarMass=86.45
 ;ni=1
 ;FC=0.35
@@ -334,7 +334,7 @@ molarMass=86.45
 [HCF141b_halocarbon]
 tau= 9.3
 rho= 0.00014
-HCF141b_emissions= csv:input/emissions/RCP45_emissions.csv
+HCF141b_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=116.9
 ;ni=2
 ;FC=0.72
@@ -342,7 +342,7 @@ molarMass=116.9
 [HCF142b_halocarbon]
 tau= 17.9
 rho= 0.0002
-HCF142b_emissions= csv:input/emissions/RCP45_emissions.csv
+HCF142b_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=100.45
 ;ni=1
 ;FC=0.36
@@ -350,14 +350,14 @@ molarMass=100.45
 ;[HCFC143_halocarbon]
 ;tau= 1.3
 ;rho= 0.00014
-;HCFC143_emissions= csv:input/emissions/RCP45_emissions.csv
+;HCFC143_emissions= csv:emissions/RCP45_emissions.csv
 ;molarMass=152.9
 
 [CH3Cl_halocarbon]
 tau= 1.3
 rho= 0.00001
 H0 = 3100.21
-CH3Cl_emissions= csv:input/emissions/RCP45_emissions.csv
+CH3Cl_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=50.45
 ;ni=1
 ;FC=0.8
@@ -366,7 +366,7 @@ molarMass=50.45
 tau= 0.7
 rho= 0.00001
 H0 = 157.267
-CH3Br_emissions= csv:input/emissions/RCP45_emissions.csv
+CH3Br_emissions= csv:emissions/RCP45_emissions.csv
 molarMass=94.9
 ;nj=1
 ;FC=1.12

--- a/input/hector_rcp26.ini
+++ b/input/hector_rcp26.ini
@@ -35,7 +35,7 @@ k_min=0.1			; min ocean heat uptake efficiency, W/m2/K
 
 ; Optional ocean C uptake constraint, Pg C/yr
 ; If supplied, the model will use these data, ignoring what it calculates
-;atm_ocean_constrain=csv:input/constraints/cmip5_oceanflux.csv
+;atm_ocean_constrain=csv:constraints/cmip5_oceanflux.csv
 
 ;------------------------------------------------------------------------
 [simpleNbox]
@@ -68,14 +68,14 @@ f_lucv=0.1			; Fraction of land use change flux from vegetation
 f_lucd=0.01			; Fraction of land use change flux from detritus (balance from soil)
 
 ; Anthropogenic contributions: direct emissions and land use change, Pg C/yr
-anthroEmissions=csv:input/emissions/RCP26_emissions.csv
-lucEmissions=csv:input/emissions/RCP26_emissions.csv 
+anthroEmissions=csv:emissions/RCP26_emissions.csv
+lucEmissions=csv:emissions/RCP26_emissions.csv 
 
 ; Optional atmospheric CO2 constraint, ppmv
 ; If supplied, the model will use these data, ignoring what it calculates
 ; Any residual between model [CO2] and model [CO2] will be put into the deep ocean
-;Ca_constrain=csv:input/constraints/lawdome_co2.csv		; Law Dome CO2 record
-;Ca_constrain=csv:input/constraints/RCP26_co2ppm.csv	; MAGICC output
+;Ca_constrain=csv:constraints/lawdome_co2.csv		; Law Dome CO2 record
+;Ca_constrain=csv:constraints/RCP26_co2ppm.csv	; MAGICC output
 
 ; CO2 and temperature effects on the carbon cycle
 ; these are global values, can optionally specify biome-specific ones as above
@@ -101,8 +101,8 @@ eps_spinup=0.001	; spinup tolerance (drift), Pg C
 [so2] 
 S0=53841.2 			; historical sulphate from year 2000 (Gg)
 SN=42000			; natural sulfur emissions (Gg)
-SO2_emissions=csv:input/emissions/RCP26_emissions.csv 	; emissions time series
-;SV=csv:input/emissions/volcanic_RF.csv   			  	; emissions time series
+SO2_emissions=csv:emissions/RCP26_emissions.csv 	; emissions time series
+;SV=csv:emissions/volcanic_RF.csv   			  	; emissions time series
 
 ;------------------------------------------------------------------------
 [CH4]
@@ -111,13 +111,13 @@ Tsoil=160 			; CH4 loss to soil (years)
 Tstrat=120          ; CH4 loss to stratosphere (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
 CH4N=300			; Natural CH4 emissions (Tgrams)
-CH4_emissions=csv:input/emissions/RCP26_emissions.csv     ; emissions time series
+CH4_emissions=csv:emissions/RCP26_emissions.csv     ; emissions time series
 
 ;------------------------------------------------------------------------
 [OH]
-NOX_emissions=csv:input/emissions/RCP26_emissions.csv     ; emissions time series
-CO_emissions=csv:input/emissions/RCP26_emissions.csv      ; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP26_emissions.csv   ; emissions time series
+NOX_emissions=csv:emissions/RCP26_emissions.csv     ; emissions time series
+CO_emissions=csv:emissions/RCP26_emissions.csv      ; emissions time series
+NMVOC_emissions=csv:emissions/RCP26_emissions.csv   ; emissions time series
 
 TOH0=6.6			; inital OH lifetime (years)
 CNOX=0.0042			; coefficent for NOX
@@ -128,9 +128,9 @@ CCH4=-0.32			; coefficent for CH4
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 				; preindustrial O3 concentration
-NOX_emissions=csv:input/emissions/RCP26_emissions.csv  	; emissions time series
-CO_emissions=csv:input/emissions/RCP26_emissions.csv	; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP26_emissions.csv ; emissions time series
+NOX_emissions=csv:emissions/RCP26_emissions.csv  	; emissions time series
+CO_emissions=csv:emissions/RCP26_emissions.csv	; emissions time series
+NMVOC_emissions=csv:emissions/RCP26_emissions.csv ; emissions time series
 ;molarMass=16.04    ; grams
 ;tau=10				; lifetime in years  (Oucher et al 2009)
 
@@ -146,7 +146,7 @@ N2ON_emissions[1765]=11  ; natural emissions in 1765
 N2ON_emissions[2000]=8   ; natural emissions in 2000 
 N2ON_emissions[2300]=8   ; natural emissions in 2300 
 
-N2O_emissions=csv:input/emissions/RCP26_emissions.csv   ; emissions time series
+N2O_emissions=csv:emissions/RCP26_emissions.csv   ; emissions time series
 ;molarMass=44.01     ; grams
 
 ;------------------------------------------------------------------------
@@ -155,7 +155,7 @@ baseyear=1750		; when to start reporting; by definition, all F=0 in this year
 
 ; Optional radiative forcing constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;Ftot_constrain=csv:input/constraints/MAGICC_RF_8.5.csv
+;Ftot_constrain=csv:constraints/MAGICC_RF_8.5.csv
 
 ;------------------------------------------------------------------------
 [temperature]
@@ -163,15 +163,15 @@ S=3.0 				; equilibrium climate sensitivity for 2xCO2, degC
 
 ; Optional global temperature constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;tgav_constrain=csv:input/constraints/tgav_historical.csv
+;tgav_constrain=csv:constraints/tgav_historical.csv
 
 ;------------------------------------------------------------------------
 [bc]
-BC_emissions=csv:input/emissions/RCP26_emissions.csv
+BC_emissions=csv:emissions/RCP26_emissions.csv
 
 ;------------------------------------------------------------------------
 [oc]
-OC_emissions=csv:input/emissions/RCP26_emissions.csv
+OC_emissions=csv:emissions/RCP26_emissions.csv
 
 ;------------------------------------------------------------------------
 ; Halocarbons
@@ -181,91 +181,91 @@ OC_emissions=csv:input/emissions/RCP26_emissions.csv
 tau=50000.0 		; lifetime in years
 rho=0.00008 		; radiative efficiencies W/m2/ppt
 H0=35.0,pptv		; preindustrial concentration, pptv
-CF4_emissions=csv:input/emissions/RCP26_emissions.csv
+CF4_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=88.0043	; grams
 
 [C2F6_halocarbon]
 tau=10000.0
 rho=0.00026
-C2F6_emissions=csv:input/emissions/RCP26_emissions.csv
+C2F6_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=138.01
 
 ;[C4F10_halocarbon]
 ;tau=2600.0
 ;rho=0.00033
-;C4F10_emissions=csv:input/emissions/RCP26_emissions.csv
+;C4F10_emissions=csv:emissions/RCP26_emissions.csv
 ;molarMass=238.0
 
 [HFC23_halocarbon]
 tau=270.0
 rho=0.00019 
-HFC23_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC23_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=70.0
 
 [HFC32_halocarbon]
 tau=4.9
 rho=0.00011 
-HFC32_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC32_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=52.0
 
 [HFC4310_halocarbon]
 tau=15.9
 rho=0.0004 
-HFC4310_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC4310_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=252.0
 
 [HFC125_halocarbon]
 tau=29.0
 rho=0.00023 
-HFC125_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC125_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=120.02
 
 [HFC134a_halocarbon]
 tau=14.0
 rho=0.00016
-HFC134a_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC134a_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=102.02
 
 [HFC143a_halocarbon]
 tau=52.0
 rho=0.00013 
-HFC143a_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC143a_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=84.04
 
 ;[HFC152a_halocarbon]
 ;tau=1.4
 ;rho=0.00009 
-;HFC152a_emissions=csv:input/emissions/RCP26_emissions.csv
+;HFC152a_emissions=csv:emissions/RCP26_emissions.csv
 ;molarMass=66.0
 
 [HFC227ea_halocarbon]
 tau=34.2
 rho=0.00026 
-HFC227ea_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC227ea_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=170.03
 
 [HFC245fa_halocarbon]
 tau=7.6
 rho=0.00028 
-HFC245fa_emissions=csv:input/emissions/RCP26_emissions.csv
+HFC245fa_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=134.0
 
 ;[HFC236fa_halocarbon]
 ;tau=240.0
 ;rho=0.00028
-;HFC236fa_emissions=csv:input/emissions/RCP26_emissions.csv
+;HFC236fa_emissions=csv:emissions/RCP26_emissions.csv
 ;molarMass=152.0
 
 [SF6_halocarbon]
 tau=3200.0
 rho=0.00052
-SF6_emissions=csv:input/emissions/RCP26_emissions.csv
+SF6_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=146.06
 
 [CFC11_halocarbon]
 tau=45.0
 rho=0.00025
-CFC11_emissions=csv:input/emissions/RCP26_emissions.csv
+CFC11_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=137.35
 ;ni=3
 ;FC=1
@@ -273,7 +273,7 @@ molarMass=137.35
 [CFC12_halocarbon]
 tau=100
 rho=0.00032
-CFC12_emissions=csv:input/emissions/RCP26_emissions.csv
+CFC12_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=120.9
 ;ni=2
 ;FC=0.6
@@ -281,7 +281,7 @@ molarMass=120.9
 [CFC113_halocarbon]
 tau=85.0
 rho=0.0003
-CFC113_emissions=csv:input/emissions/RCP26_emissions.csv
+CFC113_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=187.35
 ;ni=3
 ;FC=0.75
@@ -289,7 +289,7 @@ molarMass=187.35
 [CFC114_halocarbon]
 tau=300
 rho=0.00031
-CFC114_emissions=csv:input/emissions/RCP26_emissions.csv
+CFC114_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=170.9
 ;ni=2
 ;FC=0.28
@@ -297,13 +297,13 @@ molarMass=170.9
 [CFC115_halocarbon]
 tau=1700
 rho=0.00018
-CFC115_emissions=csv:input/emissions/RCP26_emissions.csv
+CFC115_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=154.45
 
 [CCl4_halocarbon]
 tau=26.0
 rho=0.00013
-CCl4_emissions=csv:input/emissions/RCP26_emissions.csv
+CCl4_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=153.8
 ;ni=4
 ;FC=1.06
@@ -311,7 +311,7 @@ molarMass=153.8
 [CH3CCl3_halocarbon]
 tau=5.0
 rho=0.00006
-CH3CCl3_emissions=csv:input/emissions/RCP26_emissions.csv
+CH3CCl3_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=133.35
 ;ni=3
 ;FC=1.08
@@ -319,7 +319,7 @@ molarMass=133.35
 [halon1211_halocarbon]
 tau=16.0
 rho=0.00003
-halon1211_emissions=csv:input/emissions/RCP26_emissions.csv
+halon1211_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=165.35
 ;ni=1
 ;nj=1
@@ -328,7 +328,7 @@ molarMass=165.35
 [halon1301_halocarbon]
 tau=65.0
 rho=0.00032
-halon1301_emissions=csv:input/emissions/RCP26_emissions.csv
+halon1301_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=148.9
 ;nj=1
 ;FC=0.62
@@ -336,7 +336,7 @@ molarMass=148.9
 [halon2402_halocarbon]
 tau=20.0
 rho=0.00033
-halon2402_emissions=csv:input/emissions/RCP26_emissions.csv
+halon2402_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=259.8
 ;nj=2
 ;FC=1.22
@@ -344,7 +344,7 @@ molarMass=259.8
 [HCF22_halocarbon]
 tau=12.0
 rho=0.0002
-HCF22_emissions=csv:input/emissions/RCP26_emissions.csv
+HCF22_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=86.45
 ;ni=1
 ;FC=0.35
@@ -352,7 +352,7 @@ molarMass=86.45
 [HCF141b_halocarbon]
 tau=9.3
 rho=0.00014
-HCF141b_emissions=csv:input/emissions/RCP26_emissions.csv
+HCF141b_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=116.9
 ;ni=2
 ;FC=0.72
@@ -360,7 +360,7 @@ molarMass=116.9
 [HCF142b_halocarbon]
 tau=17.9
 rho=0.0002
-HCF142b_emissions=csv:input/emissions/RCP26_emissions.csv
+HCF142b_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=100.45
 ;ni=1
 ;FC=0.36
@@ -368,14 +368,14 @@ molarMass=100.45
 ;[HCFC143_halocarbon]
 ;tau=1.3
 ;rho=0.00014
-;HCFC143_emissions=csv:input/emissions/RCP26_emissions.csv
+;HCFC143_emissions=csv:emissions/RCP26_emissions.csv
 ;molarMass=152.9
 
 [CH3Cl_halocarbon]
 tau=1.3
 rho=0.00001
 H0=504.0		; preindustrial concentration, pptv from Saito et al 2007 GRL
-CH3Cl_emissions=csv:input/emissions/RCP26_emissions.csv
+CH3Cl_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=50.45
 ;ni=1
 ;FC=0.8
@@ -384,7 +384,7 @@ molarMass=50.45
 tau=0.7
 rho=0.00001
 H0=5.8      	; preindustrial concentration, pptv from Saltzman et al 2004 JGR
-CH3Br_emissions=csv:input/emissions/RCP26_emissions.csv
+CH3Br_emissions=csv:emissions/RCP26_emissions.csv
 molarMass=94.9
 ;nj=1
 ;FC=1.12

--- a/input/hector_rcp45.ini
+++ b/input/hector_rcp45.ini
@@ -35,7 +35,7 @@ k_min=0.1			; min ocean heat uptake efficiency, W/m2/K
 
 ; Optional ocean C uptake constraint, Pg C/yr
 ; If supplied, the model will use these data, ignoring what it calculates
-;atm_ocean_constrain=csv:input/constraints/cmip5_oceanflux.csv
+;atm_ocean_constrain=csv:constraints/cmip5_oceanflux.csv
 
 ;------------------------------------------------------------------------
 [simpleNbox]
@@ -68,14 +68,14 @@ f_lucv=0.1			; Fraction of land use change flux from vegetation
 f_lucd=0.01			; Fraction of land use change flux from detritus (balance from soil)
 
 ; Anthropogenic contributions: direct emissions and land use change, Pg C/yr
-anthroEmissions=csv:input/emissions/RCP45_emissions.csv
-lucEmissions=csv:input/emissions/RCP45_emissions.csv 
+anthroEmissions=csv:emissions/RCP45_emissions.csv
+lucEmissions=csv:emissions/RCP45_emissions.csv 
 
 ; Optional atmospheric CO2 constraint, ppmv
 ; If supplied, the model will use these data, ignoring what it calculates
 ; Any residual between model [CO2] and model [CO2] will be put into the deep ocean
-;Ca_constrain=csv:input/constraints/lawdome_co2.csv		; Law Dome CO2 record
-;Ca_constrain=csv:input/constraints/RCP45_co2ppm.csv	; MAGICC output
+;Ca_constrain=csv:constraints/lawdome_co2.csv		; Law Dome CO2 record
+;Ca_constrain=csv:constraints/RCP45_co2ppm.csv	; MAGICC output
 
 ; CO2 and temperature effects on the carbon cycle
 ; these are global values, can optionally specify biome-specific ones as above
@@ -101,8 +101,8 @@ eps_spinup=0.001	; spinup tolerance (drift), Pg C
 [so2] 
 S0=53841.2 			; historical sulphate from year 2000 (Gg)
 SN=42000			; natural sulfur emissions (Gg)
-SO2_emissions=csv:input/emissions/RCP45_emissions.csv 	; emissions time series
-;SV=csv:input/emissions/volcanic_RF.csv   			  	; emissions time series
+SO2_emissions=csv:emissions/RCP45_emissions.csv 	; emissions time series
+;SV=csv:emissions/volcanic_RF.csv   			  	; emissions time series
 
 ;------------------------------------------------------------------------
 [CH4]
@@ -111,13 +111,13 @@ Tsoil=160 			; CH4 loss to soil (years)
 Tstrat=120          ; CH4 loss to stratosphere (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
 CH4N=300			; Natural CH4 emissions (Tgrams)
-CH4_emissions=csv:input/emissions/RCP45_emissions.csv     ; emissions time series
+CH4_emissions=csv:emissions/RCP45_emissions.csv     ; emissions time series
 
 ;------------------------------------------------------------------------
 [OH]
-NOX_emissions=csv:input/emissions/RCP45_emissions.csv     ; emissions time series
-CO_emissions=csv:input/emissions/RCP45_emissions.csv      ; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP45_emissions.csv   ; emissions time series
+NOX_emissions=csv:emissions/RCP45_emissions.csv     ; emissions time series
+CO_emissions=csv:emissions/RCP45_emissions.csv      ; emissions time series
+NMVOC_emissions=csv:emissions/RCP45_emissions.csv   ; emissions time series
 
 TOH0=6.6			; inital OH lifetime (years)
 CNOX=0.0042			; coefficent for NOX
@@ -128,9 +128,9 @@ CCH4=-0.32			; coefficent for CH4
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 				; preindustrial O3 concentration
-NOX_emissions=csv:input/emissions/RCP45_emissions.csv  	; emissions time series
-CO_emissions=csv:input/emissions/RCP45_emissions.csv	; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP45_emissions.csv ; emissions time series
+NOX_emissions=csv:emissions/RCP45_emissions.csv  	; emissions time series
+CO_emissions=csv:emissions/RCP45_emissions.csv	; emissions time series
+NMVOC_emissions=csv:emissions/RCP45_emissions.csv ; emissions time series
 ;molarMass=16.04    ; grams
 ;tau=10				; lifetime in years  (Oucher et al 2009)
 
@@ -146,7 +146,7 @@ N2ON_emissions[1765]=11  ; natural emissions in 1765
 N2ON_emissions[2000]=8   ; natural emissions in 2000 
 N2ON_emissions[2300]=8   ; natural emissions in 2300 
 
-N2O_emissions=csv:input/emissions/RCP45_emissions.csv   ; emissions time series
+N2O_emissions=csv:emissions/RCP45_emissions.csv   ; emissions time series
 ;molarMass=44.01     ; grams
 
 ;------------------------------------------------------------------------
@@ -155,7 +155,7 @@ baseyear=1750		; when to start reporting; by definition, all F=0 in this year
 
 ; Optional radiative forcing constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;Ftot_constrain=csv:input/constraints/MAGICC_RF_8.5.csv
+;Ftot_constrain=csv:constraints/MAGICC_RF_8.5.csv
 
 ;------------------------------------------------------------------------
 [temperature]
@@ -163,15 +163,15 @@ S=3.0 				; equilibrium climate sensitivity for 2xCO2, degC
 
 ; Optional global temperature constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;tgav_constrain=csv:input/constraints/tgav_historical.csv
+;tgav_constrain=csv:constraints/tgav_historical.csv
 
 ;------------------------------------------------------------------------
 [bc]
-BC_emissions=csv:input/emissions/RCP45_emissions.csv
+BC_emissions=csv:emissions/RCP45_emissions.csv
 
 ;------------------------------------------------------------------------
 [oc]
-OC_emissions=csv:input/emissions/RCP45_emissions.csv
+OC_emissions=csv:emissions/RCP45_emissions.csv
 
 ;------------------------------------------------------------------------
 ; Halocarbons
@@ -181,91 +181,91 @@ OC_emissions=csv:input/emissions/RCP45_emissions.csv
 tau=50000.0 		; lifetime in years
 rho=0.00008 		; radiative efficiencies W/m2/ppt
 H0=35.0,pptv		; preindustrial concentration, pptv
-CF4_emissions=csv:input/emissions/RCP45_emissions.csv
+CF4_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=88.0043	; grams
 
 [C2F6_halocarbon]
 tau=10000.0
 rho=0.00026
-C2F6_emissions=csv:input/emissions/RCP45_emissions.csv
+C2F6_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=138.01
 
 ;[C4F10_halocarbon]
 ;tau=2600.0
 ;rho=0.00033
-;C4F10_emissions=csv:input/emissions/RCP45_emissions.csv
+;C4F10_emissions=csv:emissions/RCP45_emissions.csv
 ;molarMass=238.0
 
 [HFC23_halocarbon]
 tau=270.0
 rho=0.00019 
-HFC23_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC23_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=70.0
 
 [HFC32_halocarbon]
 tau=4.9
 rho=0.00011 
-HFC32_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC32_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=52.0
 
 [HFC4310_halocarbon]
 tau=15.9
 rho=0.0004 
-HFC4310_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC4310_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=252.0
 
 [HFC125_halocarbon]
 tau=29.0
 rho=0.00023 
-HFC125_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC125_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=120.02
 
 [HFC134a_halocarbon]
 tau=14.0
 rho=0.00016
-HFC134a_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC134a_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=102.02
 
 [HFC143a_halocarbon]
 tau=52.0
 rho=0.00013 
-HFC143a_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC143a_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=84.04
 
 ;[HFC152a_halocarbon]
 ;tau=1.4
 ;rho=0.00009 
-;HFC152a_emissions=csv:input/emissions/RCP45_emissions.csv
+;HFC152a_emissions=csv:emissions/RCP45_emissions.csv
 ;molarMass=66.0
 
 [HFC227ea_halocarbon]
 tau=34.2
 rho=0.00026 
-HFC227ea_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC227ea_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=170.03
 
 [HFC245fa_halocarbon]
 tau=7.6
 rho=0.00028 
-HFC245fa_emissions=csv:input/emissions/RCP45_emissions.csv
+HFC245fa_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=134.0
 
 ;[HFC236fa_halocarbon]
 ;tau=240.0
 ;rho=0.00028
-;HFC236fa_emissions=csv:input/emissions/RCP45_emissions.csv
+;HFC236fa_emissions=csv:emissions/RCP45_emissions.csv
 ;molarMass=152.0
 
 [SF6_halocarbon]
 tau=3200.0
 rho=0.00052
-SF6_emissions=csv:input/emissions/RCP45_emissions.csv
+SF6_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=146.06
 
 [CFC11_halocarbon]
 tau=45.0
 rho=0.00025
-CFC11_emissions=csv:input/emissions/RCP45_emissions.csv
+CFC11_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=137.35
 ;ni=3
 ;FC=1
@@ -273,7 +273,7 @@ molarMass=137.35
 [CFC12_halocarbon]
 tau=100
 rho=0.00032
-CFC12_emissions=csv:input/emissions/RCP45_emissions.csv
+CFC12_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=120.9
 ;ni=2
 ;FC=0.6
@@ -281,7 +281,7 @@ molarMass=120.9
 [CFC113_halocarbon]
 tau=85.0
 rho=0.0003
-CFC113_emissions=csv:input/emissions/RCP45_emissions.csv
+CFC113_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=187.35
 ;ni=3
 ;FC=0.75
@@ -289,7 +289,7 @@ molarMass=187.35
 [CFC114_halocarbon]
 tau=300
 rho=0.00031
-CFC114_emissions=csv:input/emissions/RCP45_emissions.csv
+CFC114_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=170.9
 ;ni=2
 ;FC=0.28
@@ -297,13 +297,13 @@ molarMass=170.9
 [CFC115_halocarbon]
 tau=1700
 rho=0.00018
-CFC115_emissions=csv:input/emissions/RCP45_emissions.csv
+CFC115_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=154.45
 
 [CCl4_halocarbon]
 tau=26.0
 rho=0.00013
-CCl4_emissions=csv:input/emissions/RCP45_emissions.csv
+CCl4_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=153.8
 ;ni=4
 ;FC=1.06
@@ -311,7 +311,7 @@ molarMass=153.8
 [CH3CCl3_halocarbon]
 tau=5.0
 rho=0.00006
-CH3CCl3_emissions=csv:input/emissions/RCP45_emissions.csv
+CH3CCl3_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=133.35
 ;ni=3
 ;FC=1.08
@@ -319,7 +319,7 @@ molarMass=133.35
 [halon1211_halocarbon]
 tau=16.0
 rho=0.00003
-halon1211_emissions=csv:input/emissions/RCP45_emissions.csv
+halon1211_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=165.35
 ;ni=1
 ;nj=1
@@ -328,7 +328,7 @@ molarMass=165.35
 [halon1301_halocarbon]
 tau=65.0
 rho=0.00032
-halon1301_emissions=csv:input/emissions/RCP45_emissions.csv
+halon1301_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=148.9
 ;nj=1
 ;FC=0.62
@@ -336,7 +336,7 @@ molarMass=148.9
 [halon2402_halocarbon]
 tau=20.0
 rho=0.00033
-halon2402_emissions=csv:input/emissions/RCP45_emissions.csv
+halon2402_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=259.8
 ;nj=2
 ;FC=1.22
@@ -344,7 +344,7 @@ molarMass=259.8
 [HCF22_halocarbon]
 tau=12.0
 rho=0.0002
-HCF22_emissions=csv:input/emissions/RCP45_emissions.csv
+HCF22_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=86.45
 ;ni=1
 ;FC=0.35
@@ -352,7 +352,7 @@ molarMass=86.45
 [HCF141b_halocarbon]
 tau=9.3
 rho=0.00014
-HCF141b_emissions=csv:input/emissions/RCP45_emissions.csv
+HCF141b_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=116.9
 ;ni=2
 ;FC=0.72
@@ -360,7 +360,7 @@ molarMass=116.9
 [HCF142b_halocarbon]
 tau=17.9
 rho=0.0002
-HCF142b_emissions=csv:input/emissions/RCP45_emissions.csv
+HCF142b_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=100.45
 ;ni=1
 ;FC=0.36
@@ -368,14 +368,14 @@ molarMass=100.45
 ;[HCFC143_halocarbon]
 ;tau=1.3
 ;rho=0.00014
-;HCFC143_emissions=csv:input/emissions/RCP45_emissions.csv
+;HCFC143_emissions=csv:emissions/RCP45_emissions.csv
 ;molarMass=152.9
 
 [CH3Cl_halocarbon]
 tau=1.3
 rho=0.00001
 H0=504.0		; preindustrial concentration, pptv from Saito et al 2007 GRL
-CH3Cl_emissions=csv:input/emissions/RCP45_emissions.csv
+CH3Cl_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=50.45
 ;ni=1
 ;FC=0.8
@@ -384,7 +384,7 @@ molarMass=50.45
 tau=0.7
 rho=0.00001
 H0=5.8      	; preindustrial concentration, pptv from Saltzman et al 2004 JGR
-CH3Br_emissions=csv:input/emissions/RCP45_emissions.csv
+CH3Br_emissions=csv:emissions/RCP45_emissions.csv
 molarMass=94.9
 ;nj=1
 ;FC=1.12

--- a/input/hector_rcp60.ini
+++ b/input/hector_rcp60.ini
@@ -35,7 +35,7 @@ k_min=0.1			; min ocean heat uptake efficiency, W/m2/K
 
 ; Optional ocean C uptake constraint, Pg C/yr
 ; If supplied, the model will use these data, ignoring what it calculates
-;atm_ocean_constrain=csv:input/constraints/cmip5_oceanflux.csv
+;atm_ocean_constrain=csv:constraints/cmip5_oceanflux.csv
 
 ;------------------------------------------------------------------------
 [simpleNbox]
@@ -68,14 +68,14 @@ f_lucv=0.1			; Fraction of land use change flux from vegetation
 f_lucd=0.01			; Fraction of land use change flux from detritus (balance from soil)
 
 ; Anthropogenic contributions: direct emissions and land use change, Pg C/yr
-anthroEmissions=csv:input/emissions/RCP6_emissions.csv
-lucEmissions=csv:input/emissions/RCP6_emissions.csv 
+anthroEmissions=csv:emissions/RCP6_emissions.csv
+lucEmissions=csv:emissions/RCP6_emissions.csv 
 
 ; Optional atmospheric CO2 constraint, ppmv
 ; If supplied, the model will use these data, ignoring what it calculates
 ; Any residual between model [CO2] and model [CO2] will be put into the deep ocean
-;Ca_constrain=csv:input/constraints/lawdome_co2.csv		; Law Dome CO2 record
-;Ca_constrain=csv:input/constraints/RCP6_co2ppm.csv	; MAGICC output
+;Ca_constrain=csv:constraints/lawdome_co2.csv		; Law Dome CO2 record
+;Ca_constrain=csv:constraints/RCP6_co2ppm.csv	; MAGICC output
 
 ; CO2 and temperature effects on the carbon cycle
 ; these are global values, can optionally specify biome-specific ones as above
@@ -101,8 +101,8 @@ eps_spinup=0.001	; spinup tolerance (drift), Pg C
 [so2] 
 S0=53841.2 			; historical sulphate from year 2000 (Gg)
 SN=42000			; natural sulfur emissions (Gg)
-SO2_emissions=csv:input/emissions/RCP6_emissions.csv 	; emissions time series
-;SV=csv:input/emissions/volcanic_RF.csv   			  	; emissions time series
+SO2_emissions=csv:emissions/RCP6_emissions.csv 	; emissions time series
+;SV=csv:emissions/volcanic_RF.csv   			  	; emissions time series
 
 ;------------------------------------------------------------------------
 [CH4]
@@ -111,13 +111,13 @@ Tsoil=160 			; CH4 loss to soil (years)
 Tstrat=120          ; CH4 loss to stratosphere (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
 CH4N=300			; Natural CH4 emissions (Tgrams)
-CH4_emissions=csv:input/emissions/RCP6_emissions.csv     ; emissions time series
+CH4_emissions=csv:emissions/RCP6_emissions.csv     ; emissions time series
 
 ;------------------------------------------------------------------------
 [OH]
-NOX_emissions=csv:input/emissions/RCP6_emissions.csv     ; emissions time series
-CO_emissions=csv:input/emissions/RCP6_emissions.csv      ; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP6_emissions.csv   ; emissions time series
+NOX_emissions=csv:emissions/RCP6_emissions.csv     ; emissions time series
+CO_emissions=csv:emissions/RCP6_emissions.csv      ; emissions time series
+NMVOC_emissions=csv:emissions/RCP6_emissions.csv   ; emissions time series
 
 TOH0=6.6			; inital OH lifetime (years)
 CNOX=0.0042			; coefficent for NOX
@@ -128,9 +128,9 @@ CCH4=-0.32			; coefficent for CH4
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 				; preindustrial O3 concentration
-NOX_emissions=csv:input/emissions/RCP6_emissions.csv  	; emissions time series
-CO_emissions=csv:input/emissions/RCP6_emissions.csv	; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP6_emissions.csv ; emissions time series
+NOX_emissions=csv:emissions/RCP6_emissions.csv  	; emissions time series
+CO_emissions=csv:emissions/RCP6_emissions.csv	; emissions time series
+NMVOC_emissions=csv:emissions/RCP6_emissions.csv ; emissions time series
 ;molarMass=16.04    ; grams
 ;tau=10				; lifetime in years  (Oucher et al 2009)
 
@@ -146,7 +146,7 @@ N2ON_emissions[1765]=11  ; natural emissions in 1765
 N2ON_emissions[2000]=8   ; natural emissions in 2000 
 N2ON_emissions[2300]=8   ; natural emissions in 2300 
 
-N2O_emissions=csv:input/emissions/RCP6_emissions.csv   ; emissions time series
+N2O_emissions=csv:emissions/RCP6_emissions.csv   ; emissions time series
 ;molarMass=44.01     ; grams
 
 ;------------------------------------------------------------------------
@@ -155,7 +155,7 @@ baseyear=1750		; when to start reporting; by definition, all F=0 in this year
 
 ; Optional radiative forcing constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;Ftot_constrain=csv:input/constraints/MAGICC_RF_8.5.csv
+;Ftot_constrain=csv:constraints/MAGICC_RF_8.5.csv
 
 ;------------------------------------------------------------------------
 [temperature]
@@ -163,15 +163,15 @@ S=3.0 				; equilibrium climate sensitivity for 2xCO2, degC
 
 ; Optional global temperature constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;tgav_constrain=csv:input/constraints/tgav_historical.csv
+;tgav_constrain=csv:constraints/tgav_historical.csv
 
 ;------------------------------------------------------------------------
 [bc]
-BC_emissions=csv:input/emissions/RCP6_emissions.csv
+BC_emissions=csv:emissions/RCP6_emissions.csv
 
 ;------------------------------------------------------------------------
 [oc]
-OC_emissions=csv:input/emissions/RCP6_emissions.csv
+OC_emissions=csv:emissions/RCP6_emissions.csv
 
 ;------------------------------------------------------------------------
 ; Halocarbons
@@ -181,91 +181,91 @@ OC_emissions=csv:input/emissions/RCP6_emissions.csv
 tau=50000.0 		; lifetime in years
 rho=0.00008 		; radiative efficiencies W/m2/ppt
 H0=35.0,pptv		; preindustrial concentration, pptv
-CF4_emissions=csv:input/emissions/RCP6_emissions.csv
+CF4_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=88.0043	; grams
 
 [C2F6_halocarbon]
 tau=10000.0
 rho=0.00026
-C2F6_emissions=csv:input/emissions/RCP6_emissions.csv
+C2F6_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=138.01
 
 ;[C4F10_halocarbon]
 ;tau=2600.0
 ;rho=0.00033
-;C4F10_emissions=csv:input/emissions/RCP6_emissions.csv
+;C4F10_emissions=csv:emissions/RCP6_emissions.csv
 ;molarMass=238.0
 
 [HFC23_halocarbon]
 tau=270.0
 rho=0.00019 
-HFC23_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC23_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=70.0
 
 [HFC32_halocarbon]
 tau=4.9
 rho=0.00011 
-HFC32_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC32_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=52.0
 
 [HFC4310_halocarbon]
 tau=15.9
 rho=0.0004 
-HFC4310_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC4310_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=252.0
 
 [HFC125_halocarbon]
 tau=29.0
 rho=0.00023 
-HFC125_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC125_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=120.02
 
 [HFC134a_halocarbon]
 tau=14.0
 rho=0.00016
-HFC134a_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC134a_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=102.02
 
 [HFC143a_halocarbon]
 tau=52.0
 rho=0.00013 
-HFC143a_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC143a_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=84.04
 
 ;[HFC152a_halocarbon]
 ;tau=1.4
 ;rho=0.00009 
-;HFC152a_emissions=csv:input/emissions/RCP6_emissions.csv
+;HFC152a_emissions=csv:emissions/RCP6_emissions.csv
 ;molarMass=66.0
 
 [HFC227ea_halocarbon]
 tau=34.2
 rho=0.00026 
-HFC227ea_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC227ea_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=170.03
 
 [HFC245fa_halocarbon]
 tau=7.6
 rho=0.00028 
-HFC245fa_emissions=csv:input/emissions/RCP6_emissions.csv
+HFC245fa_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=134.0
 
 ;[HFC236fa_halocarbon]
 ;tau=240.0
 ;rho=0.00028
-;HFC236fa_emissions=csv:input/emissions/RCP6_emissions.csv
+;HFC236fa_emissions=csv:emissions/RCP6_emissions.csv
 ;molarMass=152.0
 
 [SF6_halocarbon]
 tau=3200.0
 rho=0.00052
-SF6_emissions=csv:input/emissions/RCP6_emissions.csv
+SF6_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=146.06
 
 [CFC11_halocarbon]
 tau=45.0
 rho=0.00025
-CFC11_emissions=csv:input/emissions/RCP6_emissions.csv
+CFC11_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=137.35
 ;ni=3
 ;FC=1
@@ -273,7 +273,7 @@ molarMass=137.35
 [CFC12_halocarbon]
 tau=100
 rho=0.00032
-CFC12_emissions=csv:input/emissions/RCP6_emissions.csv
+CFC12_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=120.9
 ;ni=2
 ;FC=0.6
@@ -281,7 +281,7 @@ molarMass=120.9
 [CFC113_halocarbon]
 tau=85.0
 rho=0.0003
-CFC113_emissions=csv:input/emissions/RCP6_emissions.csv
+CFC113_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=187.35
 ;ni=3
 ;FC=0.75
@@ -289,7 +289,7 @@ molarMass=187.35
 [CFC114_halocarbon]
 tau=300
 rho=0.00031
-CFC114_emissions=csv:input/emissions/RCP6_emissions.csv
+CFC114_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=170.9
 ;ni=2
 ;FC=0.28
@@ -297,13 +297,13 @@ molarMass=170.9
 [CFC115_halocarbon]
 tau=1700
 rho=0.00018
-CFC115_emissions=csv:input/emissions/RCP6_emissions.csv
+CFC115_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=154.45
 
 [CCl4_halocarbon]
 tau=26.0
 rho=0.00013
-CCl4_emissions=csv:input/emissions/RCP6_emissions.csv
+CCl4_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=153.8
 ;ni=4
 ;FC=1.06
@@ -311,7 +311,7 @@ molarMass=153.8
 [CH3CCl3_halocarbon]
 tau=5.0
 rho=0.00006
-CH3CCl3_emissions=csv:input/emissions/RCP6_emissions.csv
+CH3CCl3_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=133.35
 ;ni=3
 ;FC=1.08
@@ -319,7 +319,7 @@ molarMass=133.35
 [halon1211_halocarbon]
 tau=16.0
 rho=0.00003
-halon1211_emissions=csv:input/emissions/RCP6_emissions.csv
+halon1211_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=165.35
 ;ni=1
 ;nj=1
@@ -328,7 +328,7 @@ molarMass=165.35
 [halon1301_halocarbon]
 tau=65.0
 rho=0.00032
-halon1301_emissions=csv:input/emissions/RCP6_emissions.csv
+halon1301_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=148.9
 ;nj=1
 ;FC=0.62
@@ -336,7 +336,7 @@ molarMass=148.9
 [halon2402_halocarbon]
 tau=20.0
 rho=0.00033
-halon2402_emissions=csv:input/emissions/RCP6_emissions.csv
+halon2402_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=259.8
 ;nj=2
 ;FC=1.22
@@ -344,7 +344,7 @@ molarMass=259.8
 [HCF22_halocarbon]
 tau=12.0
 rho=0.0002
-HCF22_emissions=csv:input/emissions/RCP6_emissions.csv
+HCF22_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=86.45
 ;ni=1
 ;FC=0.35
@@ -352,7 +352,7 @@ molarMass=86.45
 [HCF141b_halocarbon]
 tau=9.3
 rho=0.00014
-HCF141b_emissions=csv:input/emissions/RCP6_emissions.csv
+HCF141b_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=116.9
 ;ni=2
 ;FC=0.72
@@ -360,7 +360,7 @@ molarMass=116.9
 [HCF142b_halocarbon]
 tau=17.9
 rho=0.0002
-HCF142b_emissions=csv:input/emissions/RCP6_emissions.csv
+HCF142b_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=100.45
 ;ni=1
 ;FC=0.36
@@ -368,14 +368,14 @@ molarMass=100.45
 ;[HCFC143_halocarbon]
 ;tau=1.3
 ;rho=0.00014
-;HCFC143_emissions=csv:input/emissions/RCP6_emissions.csv
+;HCFC143_emissions=csv:emissions/RCP6_emissions.csv
 ;molarMass=152.9
 
 [CH3Cl_halocarbon]
 tau=1.3
 rho=0.00001
 H0=504.0		; preindustrial concentration, pptv from Saito et al 2007 GRL
-CH3Cl_emissions=csv:input/emissions/RCP6_emissions.csv
+CH3Cl_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=50.45
 ;ni=1
 ;FC=0.8
@@ -384,7 +384,7 @@ molarMass=50.45
 tau=0.7
 rho=0.00001
 H0=5.8      	; preindustrial concentration, pptv from Saltzman et al 2004 JGR
-CH3Br_emissions=csv:input/emissions/RCP6_emissions.csv
+CH3Br_emissions=csv:emissions/RCP6_emissions.csv
 molarMass=94.9
 ;nj=1
 ;FC=1.12

--- a/input/hector_rcp85.ini
+++ b/input/hector_rcp85.ini
@@ -35,7 +35,7 @@ k_min=0.1			; min ocean heat uptake efficiency, W/m2/K
 
 ; Optional ocean C uptake constraint, Pg C/yr
 ; If supplied, the model will use these data, ignoring what it calculates
-;atm_ocean_constrain=csv:input/constraints/cmip5_oceanflux.csv
+;atm_ocean_constrain=csv:constraints/cmip5_oceanflux.csv
 
 ;------------------------------------------------------------------------
 [simpleNbox]
@@ -68,14 +68,14 @@ f_lucv=0.1			; Fraction of land use change flux from vegetation
 f_lucd=0.01			; Fraction of land use change flux from detritus (balance from soil)
 
 ; Anthropogenic contributions: direct emissions and land use change, Pg C/yr
-anthroEmissions=csv:input/emissions/RCP85_emissions.csv
-lucEmissions=csv:input/emissions/RCP85_emissions.csv 
+anthroEmissions=csv:emissions/RCP85_emissions.csv
+lucEmissions=csv:emissions/RCP85_emissions.csv 
 
 ; Optional atmospheric CO2 constraint, ppmv
 ; If supplied, the model will use these data, ignoring what it calculates
 ; Any residual between model [CO2] and model [CO2] will be put into the deep ocean
-;Ca_constrain=csv:input/constraints/lawdome_co2.csv		; Law Dome CO2 record
-;Ca_constrain=csv:input/constraints/RCP85_co2ppm.csv	; MAGICC output
+;Ca_constrain=csv:constraints/lawdome_co2.csv		; Law Dome CO2 record
+;Ca_constrain=csv:constraints/RCP85_co2ppm.csv	; MAGICC output
 
 ; CO2 and temperature effects on the carbon cycle
 ; these are global values, can optionally specify biome-specific ones as above
@@ -101,8 +101,8 @@ eps_spinup=0.001	; spinup tolerance (drift), Pg C
 [so2] 
 S0=53841.2 			; historical sulphate from year 2000 (Gg)
 SN=42000			; natural sulfur emissions (Gg)
-SO2_emissions=csv:input/emissions/RCP85_emissions.csv 	; emissions time series
-;SV=csv:input/emissions/volcanic_RF.csv   			  	; emissions time series
+SO2_emissions=csv:emissions/RCP85_emissions.csv 	; emissions time series
+;SV=csv:emissions/volcanic_RF.csv   			  	; emissions time series
 
 ;------------------------------------------------------------------------
 [CH4]
@@ -111,13 +111,13 @@ Tsoil=160 			; CH4 loss to soil (years)
 Tstrat=120          ; CH4 loss to stratosphere (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
 CH4N=300			; Natural CH4 emissions (Tgrams)
-CH4_emissions=csv:input/emissions/RCP85_emissions.csv     ; emissions time series
+CH4_emissions=csv:emissions/RCP85_emissions.csv     ; emissions time series
 
 ;------------------------------------------------------------------------
 [OH]
-NOX_emissions=csv:input/emissions/RCP85_emissions.csv     ; emissions time series
-CO_emissions=csv:input/emissions/RCP85_emissions.csv      ; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP85_emissions.csv   ; emissions time series
+NOX_emissions=csv:emissions/RCP85_emissions.csv     ; emissions time series
+CO_emissions=csv:emissions/RCP85_emissions.csv      ; emissions time series
+NMVOC_emissions=csv:emissions/RCP85_emissions.csv   ; emissions time series
 
 TOH0=6.6			; inital OH lifetime (years)
 CNOX=0.0042			; coefficent for NOX
@@ -128,9 +128,9 @@ CCH4=-0.32			; coefficent for CH4
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 				; preindustrial O3 concentration
-NOX_emissions=csv:input/emissions/RCP85_emissions.csv  	; emissions time series
-CO_emissions=csv:input/emissions/RCP85_emissions.csv	; emissions time series
-NMVOC_emissions=csv:input/emissions/RCP85_emissions.csv ; emissions time series
+NOX_emissions=csv:emissions/RCP85_emissions.csv  	; emissions time series
+CO_emissions=csv:emissions/RCP85_emissions.csv	; emissions time series
+NMVOC_emissions=csv:emissions/RCP85_emissions.csv ; emissions time series
 ;molarMass=16.04    ; grams
 ;tau=10				; lifetime in years  (Oucher et al 2009)
 
@@ -146,7 +146,7 @@ N2ON_emissions[1765]=11  ; natural emissions in 1765
 N2ON_emissions[2000]=8   ; natural emissions in 2000 
 N2ON_emissions[2300]=8   ; natural emissions in 2300 
 
-N2O_emissions=csv:input/emissions/RCP85_emissions.csv   ; emissions time series
+N2O_emissions=csv:emissions/RCP85_emissions.csv   ; emissions time series
 ;molarMass=44.01     ; grams
 
 ;------------------------------------------------------------------------
@@ -155,7 +155,7 @@ baseyear=1750		; when to start reporting; by definition, all F=0 in this year
 
 ; Optional radiative forcing constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;Ftot_constrain=csv:input/constraints/MAGICC_RF_8.5.csv
+;Ftot_constrain=csv:constraints/MAGICC_RF_8.5.csv
 
 ;------------------------------------------------------------------------
 [temperature]
@@ -163,15 +163,15 @@ S=3.0 				; equilibrium climate sensitivity for 2xCO2, degC
 
 ; Optional global temperature constraint
 ; If supplied, the model will use these data, ignoring what it calculates
-;tgav_constrain=csv:input/constraints/tgav_historical.csv
+;tgav_constrain=csv:constraints/tgav_historical.csv
 
 ;------------------------------------------------------------------------
 [bc]
-BC_emissions=csv:input/emissions/RCP85_emissions.csv
+BC_emissions=csv:emissions/RCP85_emissions.csv
 
 ;------------------------------------------------------------------------
 [oc]
-OC_emissions=csv:input/emissions/RCP85_emissions.csv
+OC_emissions=csv:emissions/RCP85_emissions.csv
 
 ;------------------------------------------------------------------------
 ; Halocarbons
@@ -181,91 +181,91 @@ OC_emissions=csv:input/emissions/RCP85_emissions.csv
 tau=50000.0 		; lifetime in years
 rho=0.00008 		; radiative efficiencies W/m2/ppt
 H0=35.0,pptv		; preindustrial concentration, pptv
-CF4_emissions=csv:input/emissions/RCP85_emissions.csv
+CF4_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=88.0043	; grams
 
 [C2F6_halocarbon]
 tau=10000.0
 rho=0.00026
-C2F6_emissions=csv:input/emissions/RCP85_emissions.csv
+C2F6_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=138.01
 
 ;[C4F10_halocarbon]
 ;tau=2600.0
 ;rho=0.00033
-;C4F10_emissions=csv:input/emissions/RCP85_emissions.csv
+;C4F10_emissions=csv:emissions/RCP85_emissions.csv
 ;molarMass=238.0
 
 [HFC23_halocarbon]
 tau=270.0
 rho=0.00019 
-HFC23_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC23_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=70.0
 
 [HFC32_halocarbon]
 tau=4.9
 rho=0.00011 
-HFC32_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC32_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=52.0
 
 [HFC4310_halocarbon]
 tau=15.9
 rho=0.0004 
-HFC4310_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC4310_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=252.0
 
 [HFC125_halocarbon]
 tau=29.0
 rho=0.00023 
-HFC125_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC125_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=120.02
 
 [HFC134a_halocarbon]
 tau=14.0
 rho=0.00016
-HFC134a_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC134a_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=102.02
 
 [HFC143a_halocarbon]
 tau=52.0
 rho=0.00013 
-HFC143a_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC143a_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=84.04
 
 ;[HFC152a_halocarbon]
 ;tau=1.4
 ;rho=0.00009 
-;HFC152a_emissions=csv:input/emissions/RCP85_emissions.csv
+;HFC152a_emissions=csv:emissions/RCP85_emissions.csv
 ;molarMass=66.0
 
 [HFC227ea_halocarbon]
 tau=34.2
 rho=0.00026 
-HFC227ea_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC227ea_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=170.03
 
 [HFC245fa_halocarbon]
 tau=7.6
 rho=0.00028 
-HFC245fa_emissions=csv:input/emissions/RCP85_emissions.csv
+HFC245fa_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=134.0
 
 ;[HFC236fa_halocarbon]
 ;tau=240.0
 ;rho=0.00028
-;HFC236fa_emissions=csv:input/emissions/RCP85_emissions.csv
+;HFC236fa_emissions=csv:emissions/RCP85_emissions.csv
 ;molarMass=152.0
 
 [SF6_halocarbon]
 tau=3200.0
 rho=0.00052
-SF6_emissions=csv:input/emissions/RCP85_emissions.csv
+SF6_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=146.06
 
 [CFC11_halocarbon]
 tau=45.0
 rho=0.00025
-CFC11_emissions=csv:input/emissions/RCP85_emissions.csv
+CFC11_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=137.35
 ;ni=3
 ;FC=1
@@ -273,7 +273,7 @@ molarMass=137.35
 [CFC12_halocarbon]
 tau=100
 rho=0.00032
-CFC12_emissions=csv:input/emissions/RCP85_emissions.csv
+CFC12_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=120.9
 ;ni=2
 ;FC=0.6
@@ -281,7 +281,7 @@ molarMass=120.9
 [CFC113_halocarbon]
 tau=85.0
 rho=0.0003
-CFC113_emissions=csv:input/emissions/RCP85_emissions.csv
+CFC113_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=187.35
 ;ni=3
 ;FC=0.75
@@ -289,7 +289,7 @@ molarMass=187.35
 [CFC114_halocarbon]
 tau=300
 rho=0.00031
-CFC114_emissions=csv:input/emissions/RCP85_emissions.csv
+CFC114_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=170.9
 ;ni=2
 ;FC=0.28
@@ -297,13 +297,13 @@ molarMass=170.9
 [CFC115_halocarbon]
 tau=1700
 rho=0.00018
-CFC115_emissions=csv:input/emissions/RCP85_emissions.csv
+CFC115_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=154.45
 
 [CCl4_halocarbon]
 tau=26.0
 rho=0.00013
-CCl4_emissions=csv:input/emissions/RCP85_emissions.csv
+CCl4_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=153.8
 ;ni=4
 ;FC=1.06
@@ -311,7 +311,7 @@ molarMass=153.8
 [CH3CCl3_halocarbon]
 tau=5.0
 rho=0.00006
-CH3CCl3_emissions=csv:input/emissions/RCP85_emissions.csv
+CH3CCl3_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=133.35
 ;ni=3
 ;FC=1.08
@@ -319,7 +319,7 @@ molarMass=133.35
 [halon1211_halocarbon]
 tau=16.0
 rho=0.00003
-halon1211_emissions=csv:input/emissions/RCP85_emissions.csv
+halon1211_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=165.35
 ;ni=1
 ;nj=1
@@ -328,7 +328,7 @@ molarMass=165.35
 [halon1301_halocarbon]
 tau=65.0
 rho=0.00032
-halon1301_emissions=csv:input/emissions/RCP85_emissions.csv
+halon1301_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=148.9
 ;nj=1
 ;FC=0.62
@@ -336,7 +336,7 @@ molarMass=148.9
 [halon2402_halocarbon]
 tau=20.0
 rho=0.00033
-halon2402_emissions=csv:input/emissions/RCP85_emissions.csv
+halon2402_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=259.8
 ;nj=2
 ;FC=1.22
@@ -344,7 +344,7 @@ molarMass=259.8
 [HCF22_halocarbon]
 tau=12.0
 rho=0.0002
-HCF22_emissions=csv:input/emissions/RCP85_emissions.csv
+HCF22_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=86.45
 ;ni=1
 ;FC=0.35
@@ -352,7 +352,7 @@ molarMass=86.45
 [HCF141b_halocarbon]
 tau=9.3
 rho=0.00014
-HCF141b_emissions=csv:input/emissions/RCP85_emissions.csv
+HCF141b_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=116.9
 ;ni=2
 ;FC=0.72
@@ -360,7 +360,7 @@ molarMass=116.9
 [HCF142b_halocarbon]
 tau=17.9
 rho=0.0002
-HCF142b_emissions=csv:input/emissions/RCP85_emissions.csv
+HCF142b_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=100.45
 ;ni=1
 ;FC=0.36
@@ -368,14 +368,14 @@ molarMass=100.45
 ;[HCFC143_halocarbon]
 ;tau=1.3
 ;rho=0.00014
-;HCFC143_emissions=csv:input/emissions/RCP85_emissions.csv
+;HCFC143_emissions=csv:emissions/RCP85_emissions.csv
 ;molarMass=152.9
 
 [CH3Cl_halocarbon]
 tau=1.3
 rho=0.00001
 H0=504.0		; preindustrial concentration, pptv from Saito et al 2007 GRL
-CH3Cl_emissions=csv:input/emissions/RCP85_emissions.csv
+CH3Cl_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=50.45
 ;ni=1
 ;FC=0.8
@@ -384,7 +384,7 @@ molarMass=50.45
 tau=0.7
 rho=0.00001
 H0=5.8      	; preindustrial concentration, pptv from Saltzman et al 2004 JGR
-CH3Br_emissions=csv:input/emissions/RCP85_emissions.csv
+CH3Br_emissions=csv:emissions/RCP85_emissions.csv
 molarMass=94.9
 ;nj=1
 ;FC=1.12

--- a/source/Makefile
+++ b/source/Makefile
@@ -3,7 +3,7 @@ CXXFLAGS = -g  $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
 INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR) -I$(GSLINC)
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
-LDFLAGS	 = $(CXXPROF) -L$(GSLLIB) -L. -Wl,-rpath $(GSLLIB)
+LDFLAGS	 = $(CXXPROF) -L$(GSLLIB) -L$(BOOSTLIB) -L. -Wl,-rpath $(GSLLIB) -Wl,-rpath $(BOOSTLIB)
 
 export CXXFLAGS OPTFLAGS
 
@@ -19,6 +19,7 @@ endif
 ifeq ($(strip $(BOOSTROOT)),)
 BOOSTROOT	= $(HOME)/src/boost_$(BOOSTVERSION)
 endif
+BOOSTLIB = $(BOOSTROOT)/stage/lib
 
 ## Gtest root
 GTVERS	= 1.5.0

--- a/source/Makefile
+++ b/source/Makefile
@@ -55,7 +55,7 @@ DEPS	= $(SRCS:.cpp=.d)
 
 ## default target
 hector: libhector.a main.o
-	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lgsl -lgslcblas -lm
+	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lgsl -lgslcblas -lm -lboost_system -lboost_filesystem
 
 ## alternate version that uses the capabilities needed for driving
 ## hector from an external source (e.g., an IAM) 

--- a/source/Makefile
+++ b/source/Makefile
@@ -19,7 +19,11 @@ endif
 ifeq ($(strip $(BOOSTROOT)),)
 BOOSTROOT	= $(HOME)/src/boost_$(BOOSTVERSION)
 endif
+ifeq ($(strip $(BOOSTLIB)),)
+## Default is the location used by the build scripts included with Boost, but
+## this can be overridden by setting BOOSTROOT explicitly in the enviornment.
 BOOSTLIB = $(BOOSTROOT)/stage/lib
+endif
 
 ## Gtest root
 GTVERS	= 1.5.0

--- a/source/input/ini_to_core_reader.cpp
+++ b/source/input/ini_to_core_reader.cpp
@@ -25,12 +25,15 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem.hpp>
 
 #include "core/core.hpp"
 #include "data/message_data.hpp"
 #include "input/ini_to_core_reader.hpp"
 #include "input/inih/ini.h"
 #include "input/csv_table_reader.hpp"
+
+namespace fs = boost::filesystem;
 
 namespace Hector {
   
@@ -62,6 +65,7 @@ INIToCoreReader::~INIToCoreReader() {
  *                         data.
  */
 void INIToCoreReader::parse( const string& filename ) throw ( h_exception ) {
+    iniFilePath = filename;
     int errorCode = ini_parse( filename.c_str(), valueHandler, this );
     
     // handle c errors by turning them into exceptions which can be handled later
@@ -116,6 +120,15 @@ int INIToCoreReader::valueHandler( void* user, const char* section, const char* 
             // remove the special case identifier to figure out the actual file name
             // to process
             string csvFileName( valueStr.begin() + csvFilePrefix.size(), valueStr.end() );
+            // when not an absolute path consider the CSV filepath to be
+            // relative to the INI file
+            fs::path csvFilePath( csvFileName );
+            if ( csvFilePath.is_relative() ) {
+              fs::path iniFilePath( reader->iniFilePath );
+              fs::path fullPath( iniFilePath.parent_path() / csvFilePath );
+              csvFileName = fullPath.c_str();
+            }
+
             CSVTableReader tableReader( csvFileName );
             tableReader.process( reader->core, section, nameStr );
         } else {


### PR DESCRIPTION
The CSV paths in `csv:` notation need to be given relative to the
path of the INI file. This enables running the Hector binary from
any directory without having to change the CSV path in the INI file.