### PR TITLE
Make the GSL library optional

### DIFF
--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -36,7 +36,7 @@
 namespace Hector {
   
 class unitval;
-class message_data;
+struct message_data;
 class IModelComponent;
 
 //------------------------------------------------------------------------------

--- a/headers/data/h_interpolator.hpp
+++ b/headers/data/h_interpolator.hpp
@@ -34,6 +34,7 @@ enum interpolation_methods { DEFAULT, LINEAR, SPLINE_FORSYTHE };
 // Prototypes for interpolation methods
 void spline_forsythe( int, double *, double *, double *, double *, double * );
 double seval_forsythe( int, double, double *, double *, double *, double *, double * );
+double seval_deriv_forsythe( int, double, double *, double *, double *, double *, double * );
 
 //-----------------------------------------------------------------------
 /*! \brief interpolator class header.
@@ -49,6 +50,7 @@ private:
     double *b_coef, *c_coef, *d_coef;
     
     double f_linear( double );
+    double f_deriv_linear( double );
     
     void release_data();
     void refit_data();
@@ -62,64 +64,42 @@ public:
     h_interpolator();
     ~h_interpolator();
     double f( double );
+    double f_deriv( double );
     void newdata( int, double*, double* );
     void set_method( interpolation_methods );
 };
 
 inline void h_interpolator::locate(double x, int &iprev, int &inext) const
 {
-    if(ilast>=0) {
-        iprev = ilast;
-        // search near the last-used value
-        if(xdata[iprev] <= x) {
-            inext = iprev+1;
-            if(iprev == ndata-1 || xdata[inext] >= x)
-                return;         // found it in the same interval as last time, no need to update ilast
-            else
-                inext = ndata-1; // fall through to bisection search
-        }
-        else {
-            // check the previous interval
-            inext = iprev--;
-            if(inext==0)
-                return;         // don't set ilast to iprev; since iprev<0
-            else if(xdata[iprev] <= x) {
-                ilast = iprev;  // iprev >=0 in this case
-                return;
-            }
-            else
-                iprev = 0;      // fall through to search
-        }
-    }
-
-    // no previous values, or the previous value is invalid.  set
-    // up for bisection on full array
-    // check edge cases
+    /* Test for u within the interval of definition of the interpolating function. If not,
+     return the value at an end point of the interval. */
     if(x<xdata[0]) {
       iprev = -1;
       inext = ilast = 0;
       return;
     }
-    else if(x>xdata[ndata-1]) {
+    else if(x>=xdata[ndata-1]) {
       iprev = ilast = ndata-1;
       inext = ndata;
       return;
     }
-    else {
-      iprev = 0;
-      inext = ndata-1;
-    }
     
-    // perform bisection search
-    while(inext-iprev > 1) {
-        int imid = (iprev+inext)/2;
-        if(xdata[imid] <= x)
-            iprev = imid;
-        else
-            inext = imid;
-    }
-    ilast = iprev;
+    /* Search for the data points with independent values containing the
+     argument u. */
+    if (ilast >= ndata-1 || ilast < 0) ilast = 0;
     
+    /* If u is not in the current in || ilast < 0terval, then execute a binary search. */
+    if ((x < xdata[ilast]) || (x >= xdata[ilast+1])) {
+        ilast = 0;
+        iprev = ndata + 1;
+        while (iprev > ilast + 1) {
+            inext = (int)(( ilast + iprev) / 2);
+            if (x < xdata[inext]) iprev = inext;
+            if (x >= xdata[inext]) ilast = inext;
+        }
+    }
+    iprev = ilast;
+    inext = ilast + 1;
 }
 
 }

--- a/headers/models/carbon-cycle-model.hpp
+++ b/headers/models/carbon-cycle-model.hpp
@@ -42,6 +42,9 @@
 // need to stash C values and re-try reaching next timestep
 #define CARBON_CYCLE_RETRY 1234
 
+// Signal from model to the solver that all calculations were successful
+#define ODE_SUCCESS 0
+
 namespace Hector {
 
 /*! \brief Carbon cycle model class

--- a/headers/models/oceanbox.hpp
+++ b/headers/models/oceanbox.hpp
@@ -31,9 +31,6 @@
 #include "math.h"
 #include <stdio.h> 
 #include <algorithm>
-#include <gsl/gsl_errno.h>
-#include <gsl/gsl_math.h>
-#include <gsl/gsl_min.h>
 
 #include "core/logger.hpp"
 #include "data/unitval.hpp"

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,9 +1,9 @@
 CXX	= g++
-CXXFLAGS = -g  $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
-INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR) -I$(GSLINC)
+CXXFLAGS = -g  -DHAVE_GSL=$(HAVE_GSL) $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
+INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR) $(GSLINC_FLAGS)
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
-LDFLAGS	 = $(CXXPROF) -L$(GSLLIB) -L$(BOOSTLIB) -L. -Wl,-rpath $(GSLLIB) -Wl,-rpath $(BOOSTLIB)
+LDFLAGS	 = $(CXXPROF) -L$(BOOSTLIB) -L. $(GSLLIB_FLAGS) -Wl,-rpath $(BOOSTLIB)
 
 export CXXFLAGS OPTFLAGS
 
@@ -36,6 +36,11 @@ ifeq ($(strip $(GSLROOT)),)
 GSLROOT	= /usr/local
 endif
 
+# Optionally configure hector to use GSL for ODE integration and other numerical
+# algorithms.  If not configured we fall back to boost to provide them.
+HAVE_GSL = 0
+
+ifneq ($(HAVE_GSL),0)
 ## Set the GSL include and library locations.  There is a special case for Evergreen users.
 ifeq ($(strip $(GSLROOT)),EVERGREEN)
 GSLINC  = $(GSL_INC)
@@ -45,7 +50,16 @@ CXXFLAGS = -g  $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) -MMD
 else
 GSLINC	= $(GSLROOT)/include
 GSLLIB	= $(GSLROOT)/lib
-endif
+endif # if EVERGREEN
+GSLINC_FLAGS = -I$(GSLINC)
+GSLLIB_FLAGS = -L$(GSLLIB) -Wl,-rpath,$(GSLLIB)
+GSL_LINK_FLAGS = -lgsl -lgslcblas
+else
+# Leave the GSL flags unset for compilation/linking
+GSLINC_FLAGS=
+GSLLIB_FLAGS=
+GSL_LINK_FLAGS=
+endif # if HAVE_GSL
 
 export GTLIB GTINC GSLINC GSLLIB
 
@@ -60,7 +74,7 @@ DEPS	= $(SRCS:.cpp=.d)
 
 ## default target
 hector: libhector.a main.o
-	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lgsl -lgslcblas -lm -lboost_system -lboost_filesystem
+	$(CXX) $(LDFLAGS) -o hector main.o -lhector $(GSL_LINK_FLAGS) -lm -lboost_system -lboost_filesystem
 
 ## alternate version that uses the capabilities needed for driving
 ## hector from an external source (e.g., an IAM) 

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -550,7 +550,7 @@ int  OceanComponent::calcderivs( double t, const double c[], double dcdt[] ) con
 //        std::cout << "Exceeded max_timestep of " << max_timestep << " (timeout=" << reduced_timestep_timeout << ")" << std::endl;
         return CARBON_CYCLE_RETRY;
     } else {
-        return GSL_SUCCESS;
+        return ODE_SUCCESS;
     }
 }
 

--- a/source/data/spline_forsythe.cpp
+++ b/source/data/spline_forsythe.cpp
@@ -180,7 +180,7 @@ double seval_forsythe( int n, double u, double *x, double *y, double *b, double 
     /* If u is not in the current interval, then execute a binary search. */
     if ((u < x[i]) || (u > x[i+1])) {
         i = 0;
-        j = n + 1;
+        j = n;
         while (j > i + 1) {
             k = (int)(( i + j) / 2);
             if (u < x[k]) j = k;
@@ -193,4 +193,53 @@ double seval_forsythe( int n, double u, double *x, double *y, double *b, double 
     return y[i] + dx * (b[i] + dx * (c[i] + dx * d[i]));
 }
 
+double seval_deriv_forsythe( int n, double u, double *x, double *y, double *b, double *c, double *d ) {
+    /* Evaluate the derivative of a cubic spline function.
+     seval_deriv = b(i) + 2*c(i)*(u-x(i)) + 3*d(i)*(u-x(i))**2
+     where  x(i) .lt. u .lt. x(i+1), using horner's rule.
+     If  u .lt. x(1) then  i = 1  is used.
+     If  u .ge. x(n) then  i = n  is used.
+     Input:
+     n = the number of data points
+     u = the abscissa at which the spline is to be evaluated
+     x,y = the arrays of data abscissas and ordinates
+     b,c,d = arrays of spline coefficients computed by spline
+     If  u  is not in the same interval as the previous call, then a binary search is
+     performed to determine the proper interval.
+     
+     The function seval() is invoked with the (x, y) pairs underlying the interpolating
+     function specified by the arguments x and y, and the spline coefficients that
+     define the function as specified by b, c, and d. The argument n is the number
+     of data points and the length of the coefficient arrays. */
+    
+    H_ASSERT( n && x && y && b && c && d, "seval_forsythe needs nonzero params" );
+    
+    static int i = 0;
+    int j, k;
+    double dx;
+    
+    /* Test for u within the interval of definition of the interpolating function. If not,
+     return the value at an end point of the interval. */
+    if (u < x[0]) { u = x[0]; }
+    if (u > x[n-1]) { u = x[n-1]; }
+    
+    /* Search for the data points with independent values containing the
+     argument u. */
+    if (i >= n-1) i = 0;
+    
+    /* If u is not in the current interval, then execute a binary search. */
+    if ((u < x[i]) || (u > x[i+1])) {
+        i = 0;
+        j = n;
+        while (j > i + 1) {
+            k = (int)(( i + j) / 2);
+            if (u < x[k]) j = k;
+            if (u >= x[k]) i = k;
+        }
+    }
+    
+    /* Evaluate the derivative of the spline function at the argument u. */
+    dx = u - x[i];
+    return b[i] + ( 2.0 * dx * c[i] ) + ( 3.0 * dx * dx * d[i] );
+}
 }

--- a/source/models/simpleNbox.cpp
+++ b/source/models/simpleNbox.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-#include <gsl/gsl_errno.h>
 #include <boost/lexical_cast.hpp>
 #include "boost/algorithm/string.hpp"
 
@@ -125,10 +124,12 @@ void SimpleNbox::setData( const std::string &varName,
         varNameParsed = splitvec[ 1 ];
     }
 
-    if (data.isVal)
+    if (data.isVal) {
         H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << "." << varNameParsed << "[" << data.date << "]=" << data.value_unitval << std::endl;
-    else
+    }
+    else {
         H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << "." << varNameParsed << "[" << data.date << "]=" << data.value_str << std::endl;
+    }
     try {
         // Initial pools
         if( varNameParsed == D_ATMOSPHERIC_C ) {
@@ -487,7 +488,7 @@ void SimpleNbox::accept( AVisitor* visitor ) {
 }
 
 //------------------------------------------------------------------------------
-/*! \brief            transfer model pools to flat array (for GSL ODE solver)
+/*! \brief            transfer model pools to flat array (for ODE solver)
  *  \param[in] t  time, double, the date from which ODE solver is starting
  *  \param[in] c  flat array of carbon pools (no units)
  */


### PR DESCRIPTION
Add alternatives to GSL, mostly from boost (header only), for all of the GSL algorithms used by hector so that we may make it optional. Users can configure using/not using GSL by setting the preprocessor definition HAVE_GSL to 1. This opens the door for releasing hector under a license other than GPLv2.