### PR TITLE
Add Travis CI (continuous integration) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,18 @@
 language: cpp
 
 before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev
+ - wget http://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2\?r\=\&ts\=1435589970\&use_mirror\=garr -O /tmp/boost.tar.bz2
+ - tar jxf /tmp/boost.tar.bz2
+ - mv boost_1_58_0 $PWD/boost-trunk
+ - export BOOSTROOT="$PWD/boost-trunk"
+ - export BOOSTVERSION=1_58_0
+
+ - cd $BOOSTROOT
+ - ./bootstrap.sh --with-libraries=filesystem 
+ - cd $TRAVIS_BUILD_DIR
+
+#  - sudo apt-get update -qq
+#  - sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev
 
 script: 
  - make hector

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Build Hector on Travis CI
+
+
+language: cpp
+
+before_script:
+  - sudo apt-get update -qq
+  - sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev
+
+script: 
+ - make hector
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@
 language: cpp
 
 before_script:
- - wget http://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2\?r\=\&ts\=1435589970\&use_mirror\=garr -O /tmp/boost.tar.bz2
+ - export BOOSTVERSION=1_62_0
+ - export BOOSTVERDIR=1.62.0
+ - wget http://downloads.sourceforge.net/project/boost/boost/${BOOSTVERDIR}/boost_${BOOSTVERSION}.tar.bz2\?r\=\&ts\=1435589970\&use_mirror\=garr -O /tmp/boost.tar.bz2
  - tar jxf /tmp/boost.tar.bz2
- - mv boost_1_58_0 $PWD/boost-trunk
+ - mv boost_$BOOSTVERSION $PWD/boost-trunk
  - export BOOSTROOT="$PWD/boost-trunk"
- - export BOOSTVERSION=1_58_0
 
  - cd $BOOSTROOT
  - ./bootstrap.sh --with-libraries=filesystem 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Build Hector on Travis CI
-
+# See 
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 # Build Hector on Travis CI
+# BBL October 2016
 # See https://travis-ci.org/bpbond/hector
 
 language: cpp
 
-#compiler:
-#  - clang
-#  - gcc
+compiler:
+  - clang
+  - gcc
 
 before_script:
  - export BOOSTVERSION=1_62_0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 
 language: cpp
 
+#compiler:
+#  - clang
+#  - gcc
+
 before_script:
  - export BOOSTVERSION=1_62_0
  - export BOOSTVERDIR=1.62.0
@@ -24,4 +28,5 @@ before_script:
 
 script: 
  - make hector
- 
+ - ./source/hector input/hector_rcp45.ini
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Build Hector on Travis CI
-# See 
+# See https://travis-ci.org/bpbond/hector
 
 language: cpp
 
@@ -15,6 +15,9 @@ before_script:
  - ./b2
  - cd $TRAVIS_BUILD_DIR
 
+# Code above is necessary because Travis's default Boost is 1_46_0
+# which doesn't include odeint and other stuff. Otherwise, we could
+# simple use the following lines:
 #  - sudo apt-get update -qq
 #  - sudo apt-get install libboost-dev libboost-filesystem-dev libboost-system-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 
  - cd $BOOSTROOT
  - ./bootstrap.sh --with-libraries=filesystem 
+ - ./b2
  - cd $TRAVIS_BUILD_DIR
 
 #  - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/bpbond/hector.svg?branch=travis-ci)](https://travis-ci.org/bpbond/hector)
+
 hector
 ======
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,6 +1,6 @@
 CXX	= g++
 CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
-INCLUDES = -I$(HDRDIR)
+INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR)
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
 LDFLAGS	 = $(CXXPROF) -L$(BOOSTLIB) -L. -Wl,-rpath $(BOOSTLIB)

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,6 +1,6 @@
 CXX	= g++
 CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
-INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR)
+INCLUDES = -I$(HDRDIR)
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
 LDFLAGS	 = $(CXXPROF) -L$(BOOSTLIB) -L. -Wl,-rpath $(BOOSTLIB)


### PR DESCRIPTION
Adds continuous integration, so that when someone submits a PR or commit, we get immediate feedback if it 'breaks' the model. Right now, this just checks whether the model builds on Ubuntu, but in the future we can add a OS X/clang build, check that it runs RCP4.5 test case, run dedicated testing code, etc.

Addresses issue #61 .