### PR TITLE
Fix CO2 constraint capability

### DIFF
--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -101,10 +101,10 @@ unitval OceanComponent::sendMessage( const std::string& message,
 {
     unitval returnval;
     
-    if( message==M_GETDATA ) {          //! Caller is requesting data
+    if( message == M_GETDATA ) {          //! Caller is requesting data
         return getData( datum, info.date );
         
-    } else if( message==M_SETDATA ) {   //! Caller is requesting to set data
+    } else if( message == M_SETDATA ) {   //! Caller is requesting to set data
         H_THROW("Ocean sendMessage not yet implemented for message=M_SETDATA.");
         //TODO: call setData below
         //TODO: change core so that parsing is routed through sendMessage

--- a/source/core/core.cpp
+++ b/source/core/core.cpp
@@ -573,7 +573,11 @@ unitval Core::sendMessage( const std::string& message,
                           const std::string& datum,
                           const message_data& info ) throw ( h_exception )
 {
-    if (message == M_GETDATA) {
+    if (message == M_GETDATA || message == M_DUMP_TO_DEEP_OCEAN) {
+        // M_GETDATA is used extensively by components to query each other re state
+        // M_DUMP_TO_DEEP_OCEAN is a special message used only to constrain the atmosphere
+        // We can treat it like a M_GETDATA message
+
         if(!isInited) {
             H_LOG(Logger::getGlobalLogger(), Logger::SEVERE)
                 << "message getData not available until core is initialized."
@@ -588,7 +592,7 @@ unitval Core::sendMessage( const std::string& message,
             return getComponentByName( ( *it ).second )->sendMessage( message, datum, info );
         }
     }
-    else if (message == M_SETDATA) {
+    else if (message == M_SETDATA ) {
         if( isInited ) {
             // If core initialization has been completed, then the only
             // setdata messages allowed are ones keyed to a date that we

--- a/source/models/simpleNbox.cpp
+++ b/source/models/simpleNbox.cpp
@@ -67,8 +67,8 @@ void SimpleNbox::init( Core* coreptr ) {
     core->registerDependency( D_OCEAN_CFLUX, getComponentName() );
 
     // Register the inputs we can receive from outside
-    core->registerInput(D_ANTHRO_EMISSIONS, getComponentName());
-    core->registerInput(D_LUC_EMISSIONS, getComponentName());
+    core->registerInput( D_ANTHRO_EMISSIONS, getComponentName() );
+    core->registerInput( D_LUC_EMISSIONS, getComponentName() );
 }
 
 //------------------------------------------------------------------------------
@@ -578,9 +578,11 @@ void SimpleNbox::stashCValues( double t, const double c[] )
         H_LOG( logger,Logger::DEBUG ) << t << "- have " << Ca << " want " << Ca_constrain.get( t ).value( U_PPMV_CO2 ) << std::endl;
         H_LOG( logger,Logger::DEBUG ) << t << "- have " << atmos_c << " want " << atmos_cpool_to_match << "; residual = " << residual << std::endl;
         
+        // Transfer C from atmosphere to deep ocean and update our C and Ca variables
         H_LOG( logger,Logger::DEBUG ) << "Sending residual of " << residual << " to deep ocean" << std::endl;
-        core->sendMessage( M_DUMP_TO_DEEP_OCEAN, D_OCEAN_C, message_data( residual ) );     // update ocean pool
+        core->sendMessage( M_DUMP_TO_DEEP_OCEAN, D_OCEAN_C, message_data( residual ) );
         atmos_c = atmos_c - residual;
+        Ca.set( atmos_c.value( U_PGC ) * PGC_TO_PPMVCO2, U_PPMV_CO2 );
     } else {
         residual.set( 0.0, U_PGC );
     }


### PR DESCRIPTION
Re-architecting of `sendMessage()`, etc., in the core had broken this at some point. The model now again will correctly constrain to an atmospheric CO2 level; also fixed a subtle off-by-one-year output bug.

![test](https://cloud.githubusercontent.com/assets/1956468/22027297/662f8cfe-dca1-11e6-9208-b69f93a9a60f.png)

Addresses issue #147