### PR TITLE
Fix oceanbox error when model not spun up

### DIFF
--- a/headers/models/oceanbox.hpp
+++ b/headers/models/oceanbox.hpp
@@ -92,7 +92,7 @@ public:
     // Ocean box chemistry
     oceancsys mychemistry;      //<! box chemistry
 	bool active_chemistry;      //<! box has active chemistry model?
-	void chem_equilibrate();    //<! equilibrate chemistry model to a given flux
+	void chem_equilibrate( const unitval current_Ca );    //<! equilibrate chemistry model to a given flux
     double fmin( double alk, void *params );
 
     unitval atmosphere_flux;

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -344,8 +344,8 @@ void OceanComponent::run( const double runToDate ) throw ( h_exception ) {
         H_LOG( logger, Logger::DEBUG ) << "*** Turning on chemistry models ***" << std::endl;
         surfaceHL.active_chemistry = true;
         surfaceLL.active_chemistry = true;
-        surfaceHL.chem_equilibrate();
-        surfaceLL.chem_equilibrate();
+        surfaceHL.chem_equilibrate( Ca );
+        surfaceLL.chem_equilibrate( Ca );
 
         // Warn if the user has supplied an atmosphere-ocean C flux constraint
         if( oceanflux_constrain.size() ) {
@@ -358,7 +358,7 @@ void OceanComponent::run( const double runToDate ) throw ( h_exception ) {
 	surfaceHL.compute_fluxes( Ca, 1.0, false );
 	surfaceLL.compute_fluxes( Ca, 1.0, false );
         
-        calcHeatflux( runToDate );
+    calcHeatflux( runToDate );
     
     // Now wait for the solver to call us
 }

--- a/source/models/oceanbox.cpp
+++ b/source/models/oceanbox.cpp
@@ -394,7 +394,6 @@ struct FMinWrapper {
 //------------------------------------------------------------------------------
 /*! \brief                  Equilibrate the chemistry model to a given flux
  *  \param[in] Ca           Atmospheric CO2 (ppmv)
- *  \param[in] Tgav         Mean global air temperature, change from preindustrial
  *
  *  \details The global carbon cycle can be spun up with ocean chemistry either
  *  on or off. In the former case, the ocean continually equilibrates with the
@@ -404,11 +403,14 @@ struct FMinWrapper {
  *  carbon should be in the preindustrial ocean. Before chemistry is re-enabled
  *  for the main run, however, we need to adjust ocean conditions (alkalinity)
  *  such that the chemistry model will produce the specified spinup-condition
- *  fluxes. That's what this method does.
+ *  fluxes. That's what this method does. Note that we pass in current CO2 because
+ *  in case the model was NOT spun up, need to set the box's internal tracking var.
  */
-void oceanbox::chem_equilibrate() {
+void oceanbox::chem_equilibrate( const unitval current_Ca ) {
     
 	using namespace std;
+    
+    Ca = current_Ca;
     
 	H_ASSERT( active_chemistry, "chemistry not turned on" );
 	OB_LOG( logger, Logger::DEBUG) << "Equilibrating chemistry for box " << Name << endl;
@@ -430,7 +432,6 @@ void oceanbox::chem_equilibrate() {
 	double alk_min = 2100e-6, alk_max = 2750e-6;
 	double alk = ( alk_min + alk_max ) / 2;
 	double f_target = preindustrial_flux.value( U_PGC_YR );
-
     
 	// Find a best-guess point; the GSL algorithm seems to need it
 	OB_LOG( logger, Logger::DEBUG) << "Looking for best-guess alkalinity" << endl;


### PR DESCRIPTION
`oceanbox` tracks atmospheric CO2, and normally this is set via calls to `compute_fluxes()` during spinup phase. But if there’s no spinup phase, this never gets set. This fix passes Ca in to `chem_equilibrate()`, fixing this - issue #146