### PR TITLE
Make component loggers inherit settings from global logger

### DIFF
--- a/headers/core/logger.hpp
+++ b/headers/core/logger.hpp
@@ -99,8 +99,8 @@ public:
     Logger();
     ~Logger();
     
-    void open( const std::string& logName, const bool echoToScreen,
-              LogLevel minLogLevel, const bool echoToFile = true) throw ( h_exception );
+    void open( const std::string& logName, bool echoToScreen,
+               bool echoToFile, LogLevel minLogLevel ) throw ( h_exception );
     
     bool shouldWrite( const LogLevel writeLevel ) const;
     
@@ -110,6 +110,18 @@ public:
     void close();
     
     static Logger& getGlobalLogger();
+
+    LogLevel getMinLogLevel() const {
+        return minLogLevel;
+    }
+
+    bool getEchoToFile() const {
+        return echoToFile;
+    }
+
+    bool isEnabled() const {
+        return enabled;
+    }
 };
 
 }

--- a/source/components/bc_component.cpp
+++ b/source/components/bc_component.cpp
@@ -46,7 +46,7 @@ string BlackCarbonComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void BlackCarbonComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
     

--- a/source/components/ch4_component.cpp
+++ b/source/components/ch4_component.cpp
@@ -50,7 +50,7 @@ string CH4Component::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CH4Component::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
 

--- a/source/components/dummy_model_component.cpp
+++ b/source/components/dummy_model_component.cpp
@@ -66,7 +66,7 @@ const tseries<double>& DummyModelComponent::getC() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void DummyModelComponent::init( Core* core ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
 }
 

--- a/source/components/forcing_component.cpp
+++ b/source/components/forcing_component.cpp
@@ -49,7 +49,7 @@ string ForcingComponent::getComponentName() const {
 // documentation is inherited
 void ForcingComponent::init( Core* coreptr ) {
     
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     
     core = coreptr;

--- a/source/components/halocarbon_component.cpp
+++ b/source/components/halocarbon_component.cpp
@@ -47,7 +47,7 @@ string HalocarbonComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void HalocarbonComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     //    concentration.name = myGasName;
     core = coreptr;
 

--- a/source/components/n2o_component.cpp
+++ b/source/components/n2o_component.cpp
@@ -53,7 +53,7 @@ string N2OComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void N2OComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
     oldDate = core->getStartDate();  //old date will start wehere we begin. 

--- a/source/components/o3_component.cpp
+++ b/source/components/o3_component.cpp
@@ -46,7 +46,7 @@ string OzoneComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OzoneComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
 

--- a/source/components/oc_component.cpp
+++ b/source/components/oc_component.cpp
@@ -46,7 +46,7 @@ string OrganicCarbonComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OrganicCarbonComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
   	core = coreptr;
 

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -50,7 +50,7 @@ string OceanComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OceanComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
 	
     max_timestep = OCEAN_MAX_TIMESTEP;

--- a/source/components/oh_component.cpp
+++ b/source/components/oh_component.cpp
@@ -52,7 +52,7 @@ string OHComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OHComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
 

--- a/source/components/onelineocean_component.cpp
+++ b/source/components/onelineocean_component.cpp
@@ -42,7 +42,7 @@ string OneLineOceanComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OneLineOceanComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
 	
     core = coreptr;

--- a/source/components/slr_component.cpp
+++ b/source/components/slr_component.cpp
@@ -47,7 +47,7 @@ string slrComponent::getComponentName() const {
 // documentation is inherited
 void slrComponent::init( Core* coreptr ) {
     
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     
     core = coreptr;

--- a/source/components/so2_component.cpp
+++ b/source/components/so2_component.cpp
@@ -48,7 +48,7 @@ string SulfurComponent::getComponentName() const {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void SulfurComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
 

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -74,7 +74,7 @@ void TemperatureComponent::invert_1d_2x2_matrix(double * x, double * y) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void TemperatureComponent::init( Core* coreptr ) {
-    logger.open( getComponentName(), false, Logger::DEBUG );
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     
     tgaveq.set( 0.0, U_DEGC, 0.0 );

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -41,7 +41,7 @@ CarbonCycleSolver::~CarbonCycleSolver()
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleSolver::init( Core* coreptr ) {
-    logger.open( getComponentName(), Logger::getGlobalLogger().isEnabled(), Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
+    logger.open( getComponentName(), Logger::getGlobalLogger().isEnabled(), Logger::getGlobalLogger().getEchoToFile(), Logger::WARNING );
     H_LOG( logger, Logger::DEBUG ) << getComponentName() << " initialized." << std::endl;
     
     core = coreptr;

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -41,7 +41,7 @@ CarbonCycleSolver::~CarbonCycleSolver()
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleSolver::init( Core* coreptr ) {
-    logger.open( getComponentName(), true, Logger::WARNING );
+    logger.open( getComponentName(), Logger::getGlobalLogger().isEnabled(), Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG( logger, Logger::DEBUG ) << getComponentName() << " initialized." << std::endl;
     
     core = coreptr;

--- a/source/core/logger.cpp
+++ b/source/core/logger.cpp
@@ -138,8 +138,8 @@ Logger::~Logger() {
  *                        initialized.
  *
  */
-void Logger::open( const string& logName, const bool echoToScreen,
-                   LogLevel minLogLevel, const bool echoToFile ) throw ( h_exception ) {
+void Logger::open( const string& logName, bool echoToScreen,
+                   bool echoToFile, LogLevel minLogLevel ) throw ( h_exception ) {
     H_ASSERT( !isInitialized, "This log has already been initialized." );
 
     this->minLogLevel = minLogLevel;

--- a/source/main-api.cpp
+++ b/source/main-api.cpp
@@ -46,7 +46,7 @@ int main (int argc, char * const argv[]) {
 
         // Create the global log
         Logger& glog = Logger::getGlobalLogger();
-        glog.open( string( MODEL_NAME ), true, Logger::DEBUG );
+        glog.open( string( MODEL_NAME ), true, true, Logger::DEBUG );
         H_LOG( glog, Logger::NOTICE ) << MODEL_NAME << " wrapper start" << endl;
 
         // Parse the main configuration file

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -38,7 +38,7 @@ int main (int argc, char * const argv[]) {
 	try {
         // Create the global log
         Logger& glog = Logger::getGlobalLogger();
-        glog.open( string( MODEL_NAME ), true, Logger::DEBUG );
+        glog.open( string( MODEL_NAME ), true, true, Logger::DEBUG );
         H_LOG( glog, Logger::NOTICE ) << MODEL_NAME << " wrapper start" << endl;
         
         // Parse the main configuration file

--- a/source/models/carbon-cycle-model.cpp
+++ b/source/models/carbon-cycle-model.cpp
@@ -19,7 +19,7 @@ namespace Hector {
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleModel::init( Core* core ) {
-    logger.open( getComponentName(), false, Logger::DEBUG);
+    logger.open( getComponentName(), false, Logger::getGlobalLogger().getEchoToFile(), Logger::getGlobalLogger().getMinLogLevel() );
     H_LOG(logger, Logger::DEBUG) << getComponentName() << " initialized." << std::endl;
 }
 

--- a/source/testing/test_logger.cpp
+++ b/source/testing/test_logger.cpp
@@ -30,9 +30,9 @@ protected:
         H_ASSERT( !fileExists( testFile1.c_str() ), "testfile1 exists" );
         H_ASSERT( !fileExists( testFile2.c_str() ), "testfile2 exists" );
 
-        loggerNoEcho.open( testFile1, false, Logger::WARNING );
+        loggerNoEcho.open( testFile1, false, true, Logger::WARNING );
         std::streambuf* tmpBuff = std::cout.rdbuf( &consoleTestBuff );
-        loggerEcho.open( testFile2, true, Logger::WARNING );
+        loggerEcho.open( testFile2, true, true, Logger::WARNING );
         
         // now that the logger has attached to our test buffer put the
         // original back into cout


### PR DESCRIPTION
Until component loggers can be setup using configuration ini-files, this makes it much easier to turn off logging, e.g. in Pyhector. Hector logging output should be unchanged.