### PR TITLE
Make getComponentByName public

### DIFF
--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -85,10 +85,10 @@ public:
     
     static double undefinedIndex();
     
-private:
-    
     IModelComponent* getComponentByName( const std::string& componentName
                                         ) const throw ( h_exception );
+    
+private:
     
     //------------------------------------------------------------------------------
     //! Current run name.


### PR DESCRIPTION
We use this in Pyhector. `getComponentByName` (which is `const`) is a function generally useful from outside the core.