### PR TITLE
Reset capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.app
 source/hector
 source/hector-ext
+source/hector-api
 
 # Hector logs
 logs/*.*

--- a/headers/components/bc_component.hpp
+++ b/headers/components/bc_component.hpp
@@ -47,6 +47,8 @@ public:
     virtual void prepareToRun() throw ( h_exception );
     
     virtual void run( const double runToDate ) throw ( h_exception );
+
+    virtual void reset(double time) throw(h_exception);
     
     virtual void shutDown();
     

--- a/headers/components/ch4_component.hpp
+++ b/headers/components/ch4_component.hpp
@@ -49,6 +49,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods

--- a/headers/components/component_data.hpp
+++ b/headers/components/component_data.hpp
@@ -116,7 +116,6 @@
 #define D_HC_TAU                "tau"
 #define D_HC_RHO                "rho"
 #define D_HC_MOLARMASS          "molarMass"
-#define D_HC_CALCDATE           "calcDate"
 
 // methane component
 #define D_ATMOSPHERIC_CH4       "CH4"

--- a/headers/components/dummy_model_component.hpp
+++ b/headers/components/dummy_model_component.hpp
@@ -53,6 +53,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods

--- a/headers/components/forcing_component.hpp
+++ b/headers/components/forcing_component.hpp
@@ -23,6 +23,7 @@
 //#include "core/o3_component.hpp"
 #include "core/logger.hpp"
 #include "data/tseries.hpp"
+#include "data/tvector.hpp"
 #include "data/unitval.hpp"
 #include "models/carbon-cycle-model.hpp"
 
@@ -38,7 +39,7 @@ class HalocarbonComponent;
  *
  */
 class ForcingComponent : public IModelComponent {
-    
+    friend class CSVOutputStreamVisitor;
 public:
 	
     ForcingComponent();
@@ -60,21 +61,26 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods
     virtual void accept( AVisitor* visitor );
     
     //! A list (map) of all computed forcings, with associated iterator
-    std::map<std::string, unitval > forcings, baseyear_forcings;
+    typedef std::map<std::string, unitval > forcings_t;
     typedef std::map<std::string, unitval >::iterator forcingsIterator;
-    
-	
-    
+
 private:
     virtual unitval getData( const std::string& varName,
                             const double valueIndex ) throw ( h_exception );
-    
+
+    //! Base year forcings
+    forcings_t baseyear_forcings;
+    //! Forcings by year
+    tvector<forcings_t> forcings_ts; 
+
     double baseyear;        //! Year which forcing calculations will start
     double currentYear;     //! Tracks current year
     unitval C0;             //! Records base year atmospheric CO2
@@ -82,7 +88,6 @@ private:
     tseries<unitval> Ftot_constrain;       //! Total forcing can be supplied
     
     Core* core;             //! Core
-    double oldDate;
     Logger logger;          //! Logger
 };
 

--- a/headers/components/halocarbon_component.hpp
+++ b/headers/components/halocarbon_component.hpp
@@ -52,6 +52,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods
@@ -74,7 +76,7 @@ private:
     tseries<unitval> hc_forcing;
     
     tseries<unitval> emissions;     //! Time series of emissions, pptv
-    unitval Ha;                     //! Current (ambient) concentration, pptv
+    tseries<unitval> Ha_ts;         //! Time series of (ambient) concentration, pptv
     unitval H0;                     //! Preindustrial concentration, pptv
     
     double molarMass;

--- a/headers/components/halocarbon_component.hpp
+++ b/headers/components/halocarbon_component.hpp
@@ -79,9 +79,6 @@ private:
     
     double molarMass;
     
-    //! The last calculated date value
-    double calcDate;
-    
     //! logger
     Logger logger;
 

--- a/headers/components/imodel_component.hpp
+++ b/headers/components/imodel_component.hpp
@@ -123,8 +123,38 @@ public:
      *  \return     A bool indicating whether the component is spun up.
      *  \exception  h_exception If an error occurred for any reason while running.
      */
-    virtual bool run_spinup( const int step ) throw ( h_exception ) { return true; };
-    
+    virtual bool run_spinup( const int step ) throw ( h_exception ) { return true; }
+
+    //------------------------------------------------------------------------------
+    /*! \brief Reset the component's state to what it was at some previous time.
+     *
+     *  Roll back all of the component's state variables to their
+     *  values at the input time.  Generally this should be an integer
+     *  year boundary, but this is not strictly required.  Behavior if
+     *  a noninteger date is input is currently unspecified.
+     *
+     *  The behavior on reset will be specific to each component.
+     *  Generally, the component will:
+     *     * reset its internal time counter to the input time
+     *     * truncate time series of output values after the input time
+     *     * _not_ truncate time series of input values
+     *  The input time series are not truncated because for runs where
+     *  the inputs (e.g. emissions) for the whole run are read in at
+     *  the beginning, it may not be possible to retrieve those inputs
+     *  once the initial setup is complete.  For reset purposes, a
+     *  time series is an "output" if it is calculated in the
+     *  component's run method; otherwise, it's an input.
+     *
+     *  The method will throw an exception if the component is unable
+     *  to perform the reset.  Examples of why this might occur
+     *  include an input date that is still in the future, or a date
+     *  that is before the beginning of the simulation.
+     *
+     *  \param date Date to which to reset component state
+     *  \exception h_exception If unable to perform the reset.
+     */
+    virtual void reset(double time) throw(h_exception) = 0;
+        
     //------------------------------------------------------------------------------
     /*! \brief We will no longer attempt to run the model; perform any cleanup.
      *

--- a/headers/components/n2o_component.hpp
+++ b/headers/components/n2o_component.hpp
@@ -48,6 +48,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods
@@ -59,10 +61,10 @@ private:
     
     unitval N0;    //! preindustrial N2O
     unitval UC_N2O;  //! conversion from emissions to concentration
-	tseries<unitval> N2O_emissions; //! anthropogenic emissions time series
+    tseries<unitval> N2O_emissions; //! anthropogenic emissions time series
     tseries<unitval> N2ON_emissions; //! natural emissions time series
     tseries<unitval> N2O; //! N2O concentrations
-    tseries<unitval> TAU_N2O; 
+    tseries<unitval> TAU_N2O;   //! N2O decay time constant (varies as a function of concentration).
     unitval TN2O0;  //! inital N2O lifetime (tau)
     
     //! logger

--- a/headers/components/o3_component.hpp
+++ b/headers/components/o3_component.hpp
@@ -63,8 +63,6 @@ private:
     tseries<unitval> CO_emissions;
 	tseries<unitval> NMVOC_emissions;
     tseries<unitval> NOX_emissions;
-	tseries<unitval> Ma;
-
     
     //! logger
     Logger logger;

--- a/headers/components/o3_component.hpp
+++ b/headers/components/o3_component.hpp
@@ -47,6 +47,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods
@@ -61,13 +63,13 @@ private:
     unitval PO3;
     tseries<unitval> O3;
     tseries<unitval> CO_emissions;
-	tseries<unitval> NMVOC_emissions;
+    tseries<unitval> NMVOC_emissions;
     tseries<unitval> NOX_emissions;
     
     //! logger
     Logger logger;
 
-	Core *core;
+    Core *core;
     double oldDate;
 };
 

--- a/headers/components/oc_component.hpp
+++ b/headers/components/oc_component.hpp
@@ -48,6 +48,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods

--- a/headers/components/ocean_component.hpp
+++ b/headers/components/ocean_component.hpp
@@ -16,6 +16,7 @@
 
 #include "core/logger.hpp"
 #include "data/tseries.hpp"
+#include "data/tvector.hpp"
 #include "data/unitval.hpp"
 #include "models/carbon-cycle-model.hpp"
 #include "models/ocean_csys.hpp"
@@ -72,47 +73,95 @@ public:
     int  calcderivs( double t, const double c[], double dcdt[] ) const;
     void slowparameval( double t, const double c[] );
     void stashCValues( double t, const double c[] );
+    void record_state(double t);
 
     void run1( const double runToDate ) throw ( h_exception );
 
 private:
     virtual unitval getData( const std::string& varName,
                             const double date ) throw ( h_exception );
-     // Ocean boxes
-    oceanbox surfaceHL; //!< surface high latitude box 100m
-	oceanbox surfaceLL; //!< surface low latitude box 100m
-	oceanbox inter;     //!< intermediate box 1000m
-	oceanbox deep;      //!< deep box 3000m
 
-    // Ocean conditions
+    /*****************************************************************
+     * State variables for the component
+     * All of these will need to be recorded at the end of a timestep,
+     * except for the spinup flag.
+     *****************************************************************/
+    // Ocean boxes
+    oceanbox surfaceHL; //!< surface high latitude box 100m
+    oceanbox surfaceLL; //!< surface low latitude box 100m
+    oceanbox inter;     //!< intermediate box 1000m
+    oceanbox deep;      //!< deep box 3000m
+
+    // Atmosphere conditions
     unitval Tgav;           //!< Global temperature anomaly, degC
     unitval Ca;             //!< Atmospheric CO2, ppm
+
+    // Atmosphere-ocean flux
+    unitval annualflux_sum, annualflux_sumHL, annualflux_sumLL;     //!< Running annual totals atm-ocean flux, for output reporting
+    unitval lastflux_annualized;        //!< Last atm-ocean flux when solver ordered us to 'stash' C values
+
+    // Spinup mode flag
     bool in_spinup;         //!< Are we currently in spinup?
-    bool spinup_chem;       //!< run chemistry during spinup?
-    tseries<unitval> oceanflux_constrain;      //!< atmosphere->ocean C flux data to constrain to
-    
-    // Ocean circulation
+
+
+    /*****************************************************************
+     * Model parameters
+     *****************************************************************/
+    // Ocean circulation parameters
     unitval tt;          //!< m3/s thermohaline overturning
     unitval tu;          //!< m3/s high latitude overturning
     unitval twi;         //!< m3/s warm-intermediate exchange
     unitval tid;         //!< m3/s intermediate-deep exchange
-   
-    // Carbon values
-    unitval carbon_HL;
-    unitval carbon_LL;
-    unitval carbon_IO;
-    unitval carbon_DO;
+    
+    
+    /*****************************************************************
+     * Input data
+     *****************************************************************/
+    bool spinup_chem;       //!< run chemistry during spinup?
+    tseries<unitval> oceanflux_constrain;      //!< atmosphere->ocean C flux data to constrain to
+    
 
-    // Private helper functions
+    /*****************************************************************
+     * Private helper functions
+     *****************************************************************/
     unitval totalcpool() const;
     unitval annual_totalcflux( const double date, const unitval& Ca, const double cpoolscale=1.0 ) const;
-    unitval annualflux_sum, annualflux_sumHL, annualflux_sumLL;     //!< Running annual totals atm-ocean flux, for output reporting
-    unitval lastflux_annualized;        //!< Last atm-ocean flux when solver ordered us to 'stash' C values
 
+
+    /*****************************************************************
+     * Adaptive timestep control
+     * max_timestep and reduced_timestep_timeout will need to be recorded.
+     * The timesteps counter is set to zero at the start of each year.
+     *****************************************************************/
     double max_timestep;                //!< Current maximum timestep allowed. This can change
     int reduced_timestep_timeout;       //!< Timer that keeps track of how long we've had a reduced timestep
     int timesteps;                      //!< Number of timesteps taken in current year
-       
+
+    /*****************************************************************
+     * Recording variables
+     * These are used to record the component state over time so that
+     * we can reset to a previous time.
+     *****************************************************************/
+    // Ocean boxes over time
+    tvector<oceanbox> surfaceHL_tv;
+    tvector<oceanbox> surfaceLL_tv;
+    tvector<oceanbox> inter_tv;
+    tvector<oceanbox> deep_tv;
+
+    // Ocean conditions over time
+    tseries<unitval> Tgav_ts;
+    tseries<unitval> Ca_ts;
+
+    // Atmosphere-ocean flux
+    tseries<unitval> annualflux_sum_ts;
+    tseries<unitval> annualflux_sumHL_ts;
+    tseries<unitval> annualflux_sumLL_ts;
+    tseries<unitval> lastflux_annualized_ts;
+
+    // timestep control
+    tseries<double> max_timestep_ts;
+    tseries<int> reduced_timestep_timeout_ts;
+    
     //! logger
     Logger logger;
 };

--- a/headers/components/ocean_component.hpp
+++ b/headers/components/ocean_component.hpp
@@ -60,6 +60,8 @@ public:
     
     virtual bool run_spinup( const int step ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods

--- a/headers/components/oh_component.hpp
+++ b/headers/components/oh_component.hpp
@@ -49,6 +49,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods

--- a/headers/components/onelineocean_component.hpp
+++ b/headers/components/onelineocean_component.hpp
@@ -17,6 +17,7 @@
 #include "components/imodel_component.hpp"
 #include "core/logger.hpp"
 #include "data/unitval.hpp"
+#include "data/tseries.hpp"
 
 namespace Hector {
   
@@ -48,6 +49,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods
@@ -57,14 +60,17 @@ private:
     virtual unitval getData( const std::string& varName,
                             const double date ) throw ( h_exception );
     
-	unitval total_cflux;        //!< Ocean-to-atmosphere flux, PgC/yr
-    unitval ocean_c;            //!< Total C in the ocean, PgC
+    tseries<unitval> total_cflux;        //!< Ocean-to-atmosphere flux, PgC/yr
+    tseries<unitval> ocean_c;            //!< Total C in the ocean, PgC
     
     //! pointers to other components and stuff
     Core* core;
     
     //! logger
     Logger logger;
+
+    double oldDate;
+
 };
 
 }

--- a/headers/components/slr_component.hpp
+++ b/headers/components/slr_component.hpp
@@ -52,14 +52,16 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods
     virtual void accept( AVisitor* visitor );
     
-	//! Reference period. No output occurs before we reach refperiod_high
-	int refperiod_low, refperiod_high;
-	int normalize_year;
+    //! Reference period. No output occurs before we reach refperiod_high
+    int refperiod_low, refperiod_high;
+    int normalize_year;
 	
 private:
     virtual unitval getData( const std::string& varName,
@@ -67,19 +69,22 @@ private:
     
     tseries<unitval>	sl_rc;			//!< sea level rate of change, cm/yr
     tseries<unitval>	slr;			//!< sea level rise, cm
-	tseries<unitval>	sl_rc_no_ice;   //!< sea level rate of change, cm/yr, no ice
+    tseries<unitval>	sl_rc_no_ice;   //!< sea level rate of change, cm/yr, no ice
     tseries<unitval>	slr_no_ice;		//!< sea level rise, cm, no ice
     
-	unitval             refperiod_tgav;	//!< reference period mean temperature
-	tseries<unitval>    tgav;           //!< private copy of global mean temperature
-	
-	//! pointers to other components and stuff
-	Core *core;
+    unitval             refperiod_tgav;	//!< reference period mean temperature
+    tseries<unitval>    tgav;           //!< private copy of global mean temperature
     
-	void compute_slr( const double date );
-
+    //! pointers to other components and stuff
+    Core *core;
+    
+    void compute_slr( const double date );
+    
     //! logger
     Logger logger;
+
+    //! Last date run to
+    double oldDate;
 };
 
 }

--- a/headers/components/so2_component.hpp
+++ b/headers/components/so2_component.hpp
@@ -48,14 +48,16 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double time) throw(h_exception);
+
     virtual void shutDown();
     
     // IVisitable methods
     virtual void accept( AVisitor* visitor );
     
     
-	unitval S0;    // historical value of sulfur  (YEAR?)
-	unitval SN;
+    unitval S0;    // historical value of sulfur  (YEAR?)
+    unitval SN;
 	
 private:
     virtual unitval getData( const std::string& varName,
@@ -64,12 +66,12 @@ private:
     //! Emissions time series
 	
     tseries<unitval> SO2_emissions;
-	tseries<unitval> SV;
+    tseries<unitval> SV;
     
     //! logger
     Logger logger;
 
-	Core *core;
+    Core *core;
     double oldDate;
 };
 

--- a/headers/components/temperature_component.hpp
+++ b/headers/components/temperature_component.hpp
@@ -58,6 +58,8 @@ public:
     
     virtual void run( const double runToDate ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception);
+
     virtual void shutDown();
     
     //! IVisitable methods

--- a/headers/components/temperature_component.hpp
+++ b/headers/components/temperature_component.hpp
@@ -69,7 +69,8 @@ private:
     virtual unitval getData( const std::string& varName,
                             const double date ) throw ( h_exception );
     void invert_1d_2x2_matrix( double * x, double * y);
-    
+    void setoutputs(int tstep);
+
     // Hard-coded DOECLIM parameters
     const int dt = 1;                     // years per timestep (this is implicit in Hector)
     int ns;                               // number of timesteps
@@ -128,13 +129,15 @@ private:
     std::vector<double> heat_mixed;
     std::vector<double> heat_interior;
     std::vector<double> forcing;
-    
-	    
-    unitval tgav;          //!< global temperature delta, deg C
-    unitval tgaveq;        //!< equilibrium temp without ocean heat flux, currently set = tgav
+
+    // Model parameters
     unitval S;             //!< climate sensitivity for 2xCO2, deg C
     unitval diff;          //!< ocean heat diffusivity, cm2/s
     unitval alpha;	       //!< aerosol forcing factor, unitless
+
+    // Model outputs
+    unitval tgav;          //!< global temperature delta, deg C
+    unitval tgaveq;        //!< equilibrium temp without ocean heat flux, currently set = tgav
     unitval flux_mixed;    //!< heat flux into mixed layer of ocean, W/m2
     unitval flux_interior; //!< heat flux into interior layer of ocean, W/m2
     unitval heatflux;      //!< heat flux into ocean, W/m2

--- a/headers/components/temperature_component.hpp
+++ b/headers/components/temperature_component.hpp
@@ -149,10 +149,6 @@ private:
     
     //! logger
     Logger logger;
-
-    //! persistent working space
-    double internal_Ftot;       // W/m2
-    double last_Ftot;           // W/m2
 };
 
 }

--- a/headers/core/carbon-cycle-solver.hpp
+++ b/headers/core/carbon-cycle-solver.hpp
@@ -72,6 +72,8 @@ public:
     
     virtual bool run_spinup( const int step ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception);
+
     virtual void shutDown();
     
     

--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -51,6 +51,8 @@ public:
     void prepareToRun() throw ( h_exception );
     
     void run(double runtodate=-1.0) throw ( h_exception );
+
+    void reset(double resetdate);
     
     void shutDown();
     

--- a/headers/core/core.hpp
+++ b/headers/core/core.hpp
@@ -91,6 +91,9 @@ public:
                                         ) const throw ( h_exception );
     
 private:
+    //! Cause all components to run their spinup procedure.
+    bool run_spinup();
+
     
     //------------------------------------------------------------------------------
     //! Current run name.

--- a/headers/data/tvector.hpp
+++ b/headers/data/tvector.hpp
@@ -1,0 +1,173 @@
+/* Hector -- A Simple Climate Model
+   Copyright (C) 2014-2015  Battelle Memorial Institute
+
+   Please see the accompanying file LICENSE.md for additional licensing
+   information.
+*/
+#ifndef TVECTOR_H
+#define TVECTOR_H
+/*
+ *  tvector.hpp - Vector of values indexed by time.
+ *
+ *  This class differs from the `tseries` class in that it doesn't
+ *  offer an interpolation option; therefore, it can be used with
+ *  types for which interpolation doesn't make sense, such as
+ *  containers and other structures.  The attempt to instantiate the
+ *  interp_helper class in `tseries` causes compilation to fail for
+ *  such types, even if you never intend to use it.
+ *
+ *  This problem probably could have been solved within the tseries
+ *  class with suitable application of type traits such as
+ *  `std::is_convertible`, along with metaprogramming functions, such
+ *  as `std::enable_if`, but honestly it's a lot quicker and easier
+ *  just to make a stripped down class with no interpolation functions
+ *  in it. Along the way we also add some nice-to-have functionality,
+ *  such as allowing non-const data to be modified in place.
+ *
+ */
+
+#include <map>
+#include <limits>
+#include <string>
+
+#include "core/logger.hpp"
+#include "h_exception.hpp"
+
+namespace Hector {
+  
+/*! \brief Time vector data type.
+ *
+ *  Currently implemented as an STL map.
+ */
+template <class T_data>
+class tvector {
+    std::map<double, T_data> mapdata;
+public:
+
+    void set(double, const T_data &);
+    const T_data &get(double) const throw( h_exception );
+    T_data &get(double) throw(h_exception); // allow modify-in-place
+    bool exists( double ) const;
+    
+    double firstdate() const;
+    double lastdate() const;
+    
+    int size() const;
+    
+    void truncate(double t, bool after=true);
+    
+};
+
+
+//-----------------------------------------------------------------------
+/*! \brief 'Set' for time vector data type.
+ *
+ *  Sets an (t, d) tuple, data d at time t.
+ */
+template <class T_data>
+void tvector<T_data>::set(double t, const T_data &d) {
+    mapdata[t] = d;
+}
+
+//-----------------------------------------------------------------------
+/*! \brief Does data exist at time (position) t?
+ *
+ *  Returns a bool to indicate if data exists.
+ */
+template <class T_data>
+bool tvector<T_data>::exists( double t ) const {
+    return ( mapdata.find( t ) != mapdata.end() );
+}
+
+//-----------------------------------------------------------------------
+/*! \brief 'Get' for time vector data type.
+ *
+ *  Return data associated with time t.
+ *  If no value exists, raise an exception.
+ */
+template <class T_data>
+const T_data &tvector<T_data>::get( double t ) const throw( h_exception ) {
+    typename std::map<double,T_data>::const_iterator itr = mapdata.find( t );
+    if( itr != mapdata.end() )
+        return (*itr).second;
+    else {
+        Logger& glog = Logger::getGlobalLogger();
+        H_LOG( glog, Logger::SEVERE) << "No data at requested time= " << t << std::endl;
+        H_THROW( "tvector: invalid time requested." );
+    }
+}
+
+/*! \brief mutable get method
+ *
+ * If the time vector object is not const, then get() returns a
+ * non-const reference, allowing an object to be modified in place.
+ */
+template <class T_data>
+T_data &tvector<T_data>::get( double t ) throw( h_exception ) {
+    typename std::map<double,T_data>::iterator itr = mapdata.find( t );
+    if( itr != mapdata.end() )
+        return itr->second;
+    else {
+        Logger& glog = Logger::getGlobalLogger();
+        H_LOG( glog, Logger::SEVERE) << "No data at requested time= " << t << std::endl;
+        H_THROW( "tvector: invalid time requested" );
+    }
+}   
+
+//-----------------------------------------------------------------------
+/*! \brief Return index of first element in vector.
+ *
+ *  Return index of first element in vector.
+ */
+template <class T_data>
+double tvector<T_data>::firstdate() const {
+    H_ASSERT( !mapdata.empty(), "no mapdata" );
+    return (*mapdata.begin()).first;
+}
+
+//-----------------------------------------------------------------------
+/*! \brief Return index of last element in vector.
+ *
+ *  Return index of last element in vector.
+ */
+template <class T_data>
+double tvector<T_data>::lastdate() const {
+    H_ASSERT( !mapdata.empty(), "no mapdata" );
+    return (*mapdata.rbegin()).first;
+}
+
+//-----------------------------------------------------------------------
+/*! \brief Return size of vector.
+ *
+ *  Return size of vector.
+ */
+template <class T_data>
+int tvector<T_data>::size() const {
+    return int( mapdata.size() );
+}
+
+/*! \brief truncate a time vector
+ *
+ *  \details The default is to wipe all of the data in the time vector
+ *           after the input date.  By setting the optional after
+ *           argument to false, you can wipe data before the input
+ *           date instead. 
+ */
+template <class T>
+void tvector<T>::truncate(double t, bool after)
+{
+    typename std::map<double, T>::iterator it1, it2;
+    if(after) {
+        it1 = mapdata.upper_bound(t);
+        it2 = mapdata.end();
+    }
+    else {
+        it1 = mapdata.begin();
+        it2 = mapdata.lower_bound(t);
+    } 
+    mapdata.erase(it1,it2); 
+}
+
+}
+
+#endif

--- a/headers/data/tvector.hpp
+++ b/headers/data/tvector.hpp
@@ -72,7 +72,7 @@ private:
         // representation from resulting in a misidentificaiton.
         // Right now we round to the nearest half-integer, but that could
         // change in the future, if we need more time resolution.
-        return 0.5 * std::round(2.0*t);
+        return 0.5 * ::round(2.0*t);
     }
 };
 

--- a/headers/data/unitval.hpp
+++ b/headers/data/unitval.hpp
@@ -203,7 +203,8 @@ void unitval::set( double v, unit_types u, double err=0.0 ) {
  */
 inline
 double unitval::value( unit_types u ) const throw( h_exception ) {
-    H_ASSERT( u==valUnits, "variable is not of this type" );
+    H_ASSERT( u==valUnits, "variable is not of this type.  Expected: " + unitsName(valUnits) +
+              "got: " + unitsName(u) );
     return( val );
 }
 

--- a/headers/data/unitval.hpp
+++ b/headers/data/unitval.hpp
@@ -55,17 +55,17 @@ enum unit_types {
     
                     U_PPMV_CO2,         // Atmospheric
                     U_PPBV,
-					U_PPTV,
+                    U_PPTV,
                     U_PPBV_CH4,
-					U_PPTV_CH4,
-					U_PPBV_N2O,
-					U_PPTV_N2O,
+                    U_PPTV_CH4,
+                    U_PPBV_N2O,
+                    U_PPTV_N2O,
                     U_MOL_YR,
-					U_TG_CO,
-					U_TG_CH4,
+                    U_TG_CO,
+                    U_TG_CH4,
                     U_TG_N2O,
-				    U_TG_NMVOC,
-					U_DU_O3,
+                    U_TG_NMVOC,
+                    U_DU_O3,
                     U_TG_N,             // NOX emissions given in TG-N/yr
                     U_GG_S,             // SO2 emissions in Gg-S/yr
 
@@ -85,7 +85,7 @@ enum unit_types {
                     U_GG,				// Giga-grams
                     U_MOL,
                     U_GMOL,
-					U_GT,	
+                    U_GT,	
     
                     U_PGC,              // Carbon pools and fluxes
                     U_PGC_YR,
@@ -96,13 +96,13 @@ enum unit_types {
                     
                     U_M3_S,                // sverdrop (volume transport)
                     U_PH,                  // pH
-					U_UATM,
-					U_UMOL_KG,			   // umol/kg
-					U_MOL_KG,			   // mol/kg
-					U_gC_m2_month_uatm,    //Tr variable for testing
-					U_MOL_L_ATM,		   // mol l-1 atm-1
-					U_MOL_KG_ATM,		   // mol kg-1 atm-1
-					U_J_KG_C,              // specific heat capacity
+                    U_UATM,
+                    U_UMOL_KG,			   // umol/kg
+                    U_MOL_KG,			   // mol/kg
+                    U_gC_m2_month_uatm,    //Tr variable for testing
+                    U_MOL_L_ATM,		   // mol l-1 atm-1
+                    U_MOL_KG_ATM,		   // mol kg-1 atm-1
+                    U_J_KG_C,              // specific heat capacity
 
                     U_DOBSON,               // Dobson units (ozone)
                     

--- a/headers/h_util.hpp
+++ b/headers/h_util.hpp
@@ -26,7 +26,7 @@
  * \brief The model version number to be included in logs and outputs.
  * \note This must be updated manually when the model version changes.
  */
-#define MODEL_VERSION "2.0"
+#define MODEL_VERSION "2.1.0"
 
 #define OUTPUT_DIRECTORY "output/"
 

--- a/headers/models/carbon-cycle-model.hpp
+++ b/headers/models/carbon-cycle-model.hpp
@@ -59,21 +59,6 @@ public:
     
     virtual void init( Core* core );
     
-    virtual unitval sendMessage( const std::string& message,
-                                const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
-    
-    virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
-    
-    virtual void prepareToRun() throw ( h_exception );
-    
-    virtual void run( const double runToDate ) throw ( h_exception ) = 0;
-    
-    //    virtual bool run_spinup( const int step ) throw ( h_exception );
-    
-    virtual void shutDown();
-    
     // The model interface, as seen by the solver
     
     //! Copy the values of the carbon pools into the input array,

--- a/headers/models/carbon-cycle-model.hpp
+++ b/headers/models/carbon-cycle-model.hpp
@@ -87,6 +87,19 @@ public:
     //! Copy the C values back into the model, restore units, etc.
     virtual void stashCValues( double t, const double c[] ) = 0;
     
+    //! Record the final state at the end of a time step
+    
+    //! \details This method should copy all state variables into a
+    //! time-indexed array.  Mostly this will allow the object to
+    //! reset to a previous time, but the object may also use these
+    //! arrays to provide other components with data from the entire
+    //! history of the run.  If a carbon cycle class stores
+    //! time-indexed values in the course of its normal operation,
+    //! then there might not be any need to do this copying.  In that
+    //! case, the class can inherit the default implementation of the
+    //! method, which does nothing.
+    virtual void record_state(double t) {}
+    
 protected:
     //! Number of carbon pools in the model.
     //! \details nc must be constant over the life of the calculation.

--- a/headers/models/ocean_csys.hpp
+++ b/headers/models/ocean_csys.hpp
@@ -80,7 +80,7 @@ private:
     Logger* logger;
 
     // persistent workspace
-    const int ncoeffs;
+    int ncoeffs;
     std::vector<double> m_a; 
 
 };

--- a/headers/models/simpleNbox.hpp
+++ b/headers/models/simpleNbox.hpp
@@ -75,6 +75,7 @@ public:
     int  calcderivs( double t, const double c[], double dcdt[] ) const;
     void slowparameval( double t, const double c[] );
     void stashCValues( double t, const double c[] );
+    void record_state(double t);                        //!< record the state variables at the end of the time step 
     
 private:
     virtual unitval getData( const std::string& varName,
@@ -135,11 +136,10 @@ private:
     double_stringmap co2fert;           //!< CO2 fertilization effect (unitless)
     tseries<double> Tgav_record;        //!< Record of global temperature values, for computing soil RH
     bool in_spinup;                     //!< flag tracking spinup state
-    double tcurrent;                    //!< Current time
+    double tcurrent;                    //!< Current time (last completed time step)
     double masstot;                     //!< tracker for mass conservation
-    double tlast;                       //!< last time recorded for tempferts; used to limit decline in soil Q10 effect
 
-
+    
     /*****************************************************************
      * Input data
      * This information isn't part of the state; it's either read from

--- a/headers/models/simpleNbox.hpp
+++ b/headers/models/simpleNbox.hpp
@@ -63,6 +63,8 @@ public:
     
     virtual bool run_spinup( const int step ) throw ( h_exception );
     
+    virtual void reset(double date) throw(h_exception); 
+
     virtual void shutDown();
     
     // IVisitable methods

--- a/source/Makefile
+++ b/source/Makefile
@@ -3,7 +3,7 @@ CXX      = g++
 endif
 CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD
 INCLUDES = -I$(BOOSTROOT) -I$(HDRDIR)
-WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
+WFLAGS   = -Wall -Wno-unused-local-typedefs -Wno-c++11-extensions # Turn on warnings, turn off one particularly annoying one that infests Boost libs, also turn off warning about c++-11 extensions.
 OPTFLAGS = -O3
 LDFLAGS	 = $(CXXPROF) -L$(BOOSTLIB) -L. -Wl,-rpath $(BOOSTLIB)
 
@@ -16,7 +16,7 @@ export HROOT
 
 ## Boost root
 ifeq ($(strip $(BOOSTVERSION)),)
-BOOSTVERSION	= 1_52_0
+BOOSTVERSION	= 1_63_0
 endif
 ifeq ($(strip $(BOOSTROOT)),)
 BOOSTROOT	= $(HOME)/src/boost_$(BOOSTVERSION)

--- a/source/components/bc_component.cpp
+++ b/source/components/bc_component.cpp
@@ -138,7 +138,7 @@ void BlackCarbonComponent::reset(double time) throw(h_exception)
     // reset.
     oldDate = time;
     H_LOG(logger, Logger::NOTICE)
-        << getComponentName() << " resetting to time= " << time << "\n";
+        << getComponentName() << " reset to time= " << time << "\n";
 }
 
 

--- a/source/components/bc_component.cpp
+++ b/source/components/bc_component.cpp
@@ -132,6 +132,16 @@ unitval BlackCarbonComponent::getData( const std::string& varName,
     return returnval;
 }
 
+void BlackCarbonComponent::reset(double time) throw(h_exception)
+{
+    // Set time counter to requested date; there are no outputs to
+    // reset.
+    oldDate = time;
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " resetting to time= " << time << "\n";
+}
+
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void BlackCarbonComponent::shutDown() {

--- a/source/components/ch4_component.cpp
+++ b/source/components/ch4_component.cpp
@@ -185,6 +185,16 @@ unitval CH4Component::getData( const std::string& varName,
     return returnval;
 }
 
+void CH4Component::reset(double time) throw(h_exception)
+{
+    // reset the internal time counter and truncate concentration time
+    // series
+    oldDate = time;
+    CH4.truncate(time);
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CH4Component::shutDown() {

--- a/source/components/dummy_model_component.cpp
+++ b/source/components/dummy_model_component.cpp
@@ -160,6 +160,13 @@ unitval DummyModelComponent::getData( const std::string& varName,
     return returnval;
 }
 
+void DummyModelComponent::reset(double time) throw(h_exception)
+{
+    // This is a no-op for this component
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void DummyModelComponent::shutDown() {

--- a/source/components/halocarbon_component.cpp
+++ b/source/components/halocarbon_component.cpp
@@ -165,26 +165,6 @@ void HalocarbonComponent::run( const double runToDate ) throw ( h_exception ) {
     unitval rf;
     rf.set( rho.value( U_W_M2_PPTV ) * Ha.value( U_PPTV ), U_W_M2 );
     hc_forcing.set( runToDate, rf );
-    
-    /*
-     if( runToDate <= calcDate ) {
-     unitval temp;
-     temp.set( rho.value( U_W_M2_PPTV ) * concentration.get( runToDate ).value( U_PPTV ), U_W_M2 );
-     hc_forcing.set( runToDate, temp );
-     return;
-     } // just use this code to take the emissions and convert to concentrations and then get the forcing.  keep running track of what the concentration is
-     for( ; calcDate < runToDate; ++calcDate ) {
-     double currDate = calcDate + 1;
-     H_LOG( logger, Logger::DEBUG ) << "date: " << currDate << endl;
-     unitval concentrationBack = rk( calcDate, currDate );
-     H_LOG( logger, Logger::DEBUG ) << "concentration: " << concentrationBack << endl;
-     concentration.set( currDate, concentrationBack );
-     unitval forcingBack;
-     forcingBack.set( rho.value( U_W_M2_PPTV ) * concentrationBack.value( U_PPTV ), U_W_M2 );
-     H_LOG( logger, Logger::DEBUG ) << "forcing: " << forcingBack << endl;
-     hc_forcing.set( currDate, forcingBack );
-     }
-     */
 }
 
 //------------------------------------------------------------------------------
@@ -209,9 +189,6 @@ unitval HalocarbonComponent::getData( const std::string& varName,
             returnval = emissions.get( date );
         else
             returnval.set( 0.0, U_GG );
-    } else if( varName == D_HC_CALCDATE ) {
-        H_ASSERT( date == Core::undefinedIndex(), "Date not allowed for calcdate" );
-        returnval.set( calcDate, U_UNITLESS );
     } else {
         H_THROW( "Caller is requesting unknown variable: " + varName );
     }

--- a/source/components/n2o_component.cpp
+++ b/source/components/n2o_component.cpp
@@ -176,6 +176,16 @@ unitval N2OComponent::getData( const std::string& varName,
     return returnval;
 }
 
+void N2OComponent::reset(double time) throw(h_exception)
+{
+    // reset time counter, and truncate output time series
+    oldDate = time;
+    N2O.truncate(time);
+    TAU_N2O.truncate(time);
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void N2OComponent::shutDown() {

--- a/source/components/o3_component.cpp
+++ b/source/components/o3_component.cpp
@@ -53,7 +53,6 @@ void OzoneComponent::init( Core* coreptr ) {
     CO_emissions.allowInterp( true );
     NMVOC_emissions.allowInterp( true );
     NOX_emissions.allowInterp( true );//Inputs like CO and NMVOC and NOX,
-    Ma.allowInterp( true );
     O3.allowInterp(true);
 
    

--- a/source/components/o3_component.cpp
+++ b/source/components/o3_component.cpp
@@ -164,6 +164,15 @@ unitval OzoneComponent::getData( const std::string& varName,
     return returnval;
 }
 
+
+void OzoneComponent::reset(double time) throw(h_exception)
+{
+    O3.truncate(time);
+    oldDate = time;
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OzoneComponent::shutDown() {

--- a/source/components/oc_component.cpp
+++ b/source/components/oc_component.cpp
@@ -134,6 +134,13 @@ unitval OrganicCarbonComponent::getData( const std::string& varName,
     return returnval;
 }
 
+void OrganicCarbonComponent::reset(double time) throw(h_exception)
+{
+    oldDate = time;
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OrganicCarbonComponent::shutDown() {

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -559,6 +559,15 @@ void OceanComponent::stashCValues( double t, const double c[] ) {
     
    }
 
+
+void OceanComponent::reset(double time) throw(h_exception)
+{
+    H_THROW("OceanComponent::reset : not yet implemented.")
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OceanComponent::shutDown() {

--- a/source/components/ocean_component.cpp
+++ b/source/components/ocean_component.cpp
@@ -590,6 +590,8 @@ void OceanComponent::reset(double time) throw(h_exception)
 
 void OceanComponent::record_state(double time)
 {
+    H_LOG(logger, Logger::DEBUG) << "Recording component state at t= "
+                                 << time << endl;
     surfaceHL_tv.set(time, surfaceHL);
     surfaceLL_tv.set(time, surfaceLL);
     inter_tv.set(time, inter);

--- a/source/components/oh_component.cpp
+++ b/source/components/oh_component.cpp
@@ -130,7 +130,7 @@ void OHComponent::setData( const string& varName,
 void OHComponent::prepareToRun() throw ( h_exception ) {
     
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
-	oldDate = core->getStartDate();
+    oldDate = core->getStartDate();
     //get intial CH4 concentration
      M0 = core->sendMessage( M_GETDATA, D_PREINDUSTRIAL_CH4 );
     TAU_OH.set( oldDate, TOH0 );
@@ -183,6 +183,15 @@ unitval OHComponent::getData( const std::string& varName,
     
     return returnval;
 }
+
+void OHComponent::reset(double time) throw(h_exception)
+{
+    oldDate = time;
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
 
 //------------------------------------------------------------------------------
 // documentation is inherited

--- a/source/components/slr_component.cpp
+++ b/source/components/slr_component.cpp
@@ -104,8 +104,8 @@ void slrComponent::setData( const string& varName,
 void slrComponent::prepareToRun() throw ( h_exception ) {
     
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
-    
-	H_ASSERT( refperiod_high >= refperiod_low, "bad refperiod" );
+    oldDate = core->getStartDate();
+    H_ASSERT( refperiod_high >= refperiod_low, "bad refperiod" );
 }
 
 //------------------------------------------------------------------------------
@@ -120,24 +120,24 @@ tseries<double> tgav_vals;
  */
 void slrComponent::compute_slr( const double date ) {
     
-	unitval T = tgav.get( date ) - refperiod_tgav;      // temperature relative to 1951-1980 mean
+    unitval T = tgav.get( date ) - refperiod_tgav;      // temperature relative to 1951-1980 mean
     
-	// First need to compute dTdt, the first derivative of the temperature curve
-	double dTdt_double = 0.0;
-	if( tgav.size() > 2 ) {
-		for( int i=tgav.firstdate(); i<=tgav.lastdate(); i++ ) {
-			tgav_vals.set( i, tgav.get( i ).value( U_DEGC ) );
-		}
-		tgav_vals.allowInterp( true );		// deriv needs a continuous function
+    // First need to compute dTdt, the first derivative of the temperature curve
+    double dTdt_double = 0.0;
+    if( tgav.size() > 2 ) {
+        for( int i=tgav.firstdate(); i<=tgav.lastdate(); i++ ) {
+            tgav_vals.set( i, tgav.get( i ).value( U_DEGC ) );
+        }
+        tgav_vals.allowInterp( true );		// deriv needs a continuous function
         dTdt_double = tgav_vals.get_deriv( date );
-	}
-	
-	// These values and formula below are from:
-	// Vermeer, M. and S. Rahmstorf (2009). "Global sea level linked to global temperature." PNAS 106(51): 21527-21532.
-	// This incorporates both thermal expansion and ice melt
-	const double a	= 0.56;		// cm / year / K
-	const double b	= -4.9 ;	// cm / K
-	unitval T0;
+    }
+    
+    // These values and formula below are from:
+    // Vermeer, M. and S. Rahmstorf (2009). "Global sea level linked to global temperature." PNAS 106(51): 21527-21532.
+    // This incorporates both thermal expansion and ice melt
+    const double a	= 0.56;		// cm / year / K
+    const double b	= -4.9 ;	// cm / K
+    unitval T0;
     T0.set( -0.41, U_DEGC );
     
     unitval dHdt;
@@ -147,39 +147,39 @@ void slrComponent::compute_slr( const double date ) {
     unitval dH;
     dH.set( dHdt.value( U_CM_YR ), U_CM );          // integrating to 1 year
     
-	unitval slr_to_date;
+    unitval slr_to_date;
     slr_to_date.set( 0.0, U_CM );
-	if( slr.exists( date-1 ) ) {
-		slr_to_date.set( slr.get( date-1 ).value( U_CM ), U_CM );
-	}
-	slr.set( date, slr_to_date + dH );
+    if( slr.exists( date-1 ) ) {
+        slr_to_date.set( slr.get( date-1 ).value( U_CM ), U_CM );
+    }
+    slr.set( date, slr_to_date + dH );
     
-    unitval X = slr.get( date );     // TODO: why doesn't this work in the log statement below? (Pralit?)
-	H_LOG( logger, Logger::DEBUG ) << date << " T=" << T << " dTdt=" << dTdt_double << " dHdt=" << dHdt << " slr=" << X << std::endl ;
+    unitval X = slr.get( date );
+    H_LOG( logger, Logger::DEBUG ) << date << " T=" << T << " dTdt=" << dTdt_double << " dHdt=" << dHdt << " slr=" << X << std::endl ;
     
-	// These values incorporate only thermal expansion
-	const double a_no_ice	= 0.08;		// cm / year / degree C
-	const double b_no_ice	= 2.5;		// cm / degree C
-	unitval T0_no_ice;
+    // These values incorporate only thermal expansion
+    const double a_no_ice	= 0.08;		// cm / year / degree C
+    const double b_no_ice	= 2.5;		// cm / degree C
+    unitval T0_no_ice;
     T0_no_ice.set (-0.375, U_DEGC );	// K
 	
-	unitval dHdt_no_ice;
+    unitval dHdt_no_ice;
     dHdt_no_ice.set( a_no_ice * ( T-T0_no_ice ).value( U_DEGC ) + b_no_ice * dTdt_double, U_CM_YR );		// cm/yr
-	sl_rc_no_ice.set( date, dHdt_no_ice );
+    sl_rc_no_ice.set( date, dHdt_no_ice );
 	
     unitval dH_no_ice;
     dH_no_ice.set( dHdt_no_ice.value( U_CM_YR ), U_CM );          // integrating to 1 year
     
     unitval slr_no_ice_to_date;
     slr_no_ice_to_date.set( 0.0, U_CM );
-	if( slr_no_ice.exists( date-1 ) ) {
-		slr_no_ice_to_date = slr_no_ice.get( date-1 );
-	}
-	
-	slr_no_ice.set( date, slr_no_ice_to_date + dH_no_ice );
+    if( slr_no_ice.exists( date-1 ) ) {
+        slr_no_ice_to_date = slr_no_ice.get( date-1 );
+    }
     
-    unitval Y = slr_no_ice.get( date );     // TODO: why doesn't this work in the log statement below? (Pralit?)
-	H_LOG( logger, Logger::DEBUG ) << date << " T=" << T << " Dtdt=" << dTdt_double << " DHdt_no_ice=" << dHdt_no_ice << " slr_no_ice=" << Y << std::endl ;
+    slr_no_ice.set( date, slr_no_ice_to_date + dH_no_ice );
+    
+    unitval Y = slr_no_ice.get( date );
+    H_LOG( logger, Logger::DEBUG ) << date << " T=" << T << " Dtdt=" << dTdt_double << " DHdt_no_ice=" << dHdt_no_ice << " slr_no_ice=" << Y << std::endl ;
 }
 
 //------------------------------------------------------------------------------
@@ -188,27 +188,28 @@ void slrComponent::run( const double runToDate ) throw ( h_exception ) {
     
     H_LOG( logger, Logger::DEBUG ) << "SLR run " << runToDate << std::endl;
     
-	// Sea level rise is different from some of the other model outputs, because the formula used here to compute it
-	// depends on knowing a reference period temperature
+    // Sea level rise is different from some of the other model outputs, because the formula used here to compute it
+    // depends on knowing a reference period temperature
 	
-	tgav.set( runToDate, core->sendMessage( M_GETDATA, D_GLOBAL_TEMP ) );	// store global temperature
+    tgav.set( runToDate, core->sendMessage( M_GETDATA, D_GLOBAL_TEMP ) );	// store global temperature
     
-	if( runToDate==refperiod_high ) {	// then compute reference period temperature
+    if( runToDate==refperiod_high ) {	// then compute reference period temperature
         H_LOG( logger, Logger::DEBUG ) << "Computing reference temperature" << std::endl;
         double sum = 0.0;
-		for( int i=refperiod_low; i<=refperiod_high; i++ )
-			sum += tgav.get( i ).value( U_DEGC );
-		refperiod_tgav.set( sum / ( refperiod_high - refperiod_low + 1 ), U_DEGC );
-		H_LOG( logger, Logger::DEBUG ) << "Computed reference temperature " << refperiod_tgav.value( U_DEGC ) <<
-        " (" << refperiod_low << "-" << refperiod_high << ")" << std::endl;
+        for( int i=refperiod_low; i<=refperiod_high; i++ )
+            sum += tgav.get( i ).value( U_DEGC );
+        refperiod_tgav.set( sum / ( refperiod_high - refperiod_low + 1 ), U_DEGC );
+        H_LOG( logger, Logger::DEBUG ) << "Computed reference temperature " 
+                                       << refperiod_tgav.value( U_DEGC ) << " (" << refperiod_low << "-" << refperiod_high << ")" << std::endl;
         
-		// Now we can compute and store data up to this point
-		for( int i=tgav.firstdate(); i<=refperiod_high; i++ )
-			compute_slr( i );
-	}
+        // Now we can compute and store data up to this point
+        for( int i=tgav.firstdate(); i<=refperiod_high; i++ )
+            compute_slr( i );
+    }
     
-	if( runToDate > refperiod_high )
-		compute_slr( runToDate );
+    if( runToDate > refperiod_high )
+        compute_slr( runToDate );
+    oldDate = runToDate;
 }
 
 //------------------------------------------------------------------------------
@@ -235,6 +236,21 @@ unitval slrComponent::getData( const std::string& varName,
     return returnval;
 }
 
+void slrComponent::reset(double time) throw(h_exception)
+{
+    oldDate = time;
+    sl_rc.truncate(time);
+    slr.truncate(time);
+    sl_rc_no_ice.truncate(time);
+    slr_no_ice.truncate(time);
+    tgav.truncate(time);
+    
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
+    
 //------------------------------------------------------------------------------
 // documentation is inherited
 void slrComponent::shutDown() {

--- a/source/components/so2_component.cpp
+++ b/source/components/so2_component.cpp
@@ -56,7 +56,7 @@ void SulfurComponent::init( Core* coreptr ) {
     core->registerCapability( D_NATURAL_SO2, getComponentName() );
     core->registerCapability( D_2000_SO2, getComponentName() );
     core->registerCapability( D_EMISSIONS_SO2, getComponentName() );
-	core->registerCapability( D_VOLCANIC_SO2, getComponentName() );
+    core->registerCapability( D_VOLCANIC_SO2, getComponentName() );
     // accept anthro emissions and volcanic emissions as inputs
     core->registerInput(D_EMISSIONS_SO2, getComponentName());
     core->registerInput(D_VOLCANIC_SO2, getComponentName());
@@ -124,13 +124,13 @@ void SulfurComponent::setData( const string& varName,
 void SulfurComponent::prepareToRun() throw ( h_exception ) {
     
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
-	oldDate = core->getStartDate();
+    oldDate = core->getStartDate();
 }
 
 //------------------------------------------------------------------------------
 // documentation is inherited
 void SulfurComponent::run( const double runToDate ) throw ( h_exception ) {
-	H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
+    H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
     oldDate = runToDate;
 }
 
@@ -164,6 +164,17 @@ unitval SulfurComponent::getData( const std::string& varName,
     
     return returnval;
 }
+
+void SulfurComponent::reset(double time) throw(h_exception)
+{
+    // This component doesn't calculate anything, so all we have to do
+    // is reset the time counter.
+    oldDate = time;
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
 
 //------------------------------------------------------------------------------
 // documentation is inherited

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -450,6 +450,15 @@ unitval TemperatureComponent::getData( const std::string& varName,
 }
 
 
+void TemperatureComponent::reset(double time) throw(h_exception)
+{
+    H_THROW("TemperatureComponent::reset : not yet implemented.")
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void TemperatureComponent::shutDown() {

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -453,15 +453,14 @@ unitval TemperatureComponent::getData( const std::string& varName,
 
 void TemperatureComponent::reset(double time) throw(h_exception)
 {
-    H_THROW("TemperatureComponent::reset : not yet implemented.")
-    H_LOG(logger, Logger::NOTICE)
-        << getComponentName() << " reset to time= " << time << "\n";
     // We take a slightly different approach in this component's reset method than we have in other components.  The
     // temperature component doesn't have its own time counter, and it stores its history in a collection of double
     // vectors.  Therefore, all we do here is set the unitval versions of that stored data to their values from the
     // vectors.
     int tstep = time - core->getStartDate();
     setoutputs(tstep);
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
 }
 
 

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -317,14 +317,18 @@ void TemperatureComponent::run( const double runToDate ) throw ( h_exception ) {
     // If the user has supplied temperature data, use that (except if past its end)
     if( tgav_constrain.size() && runToDate <= tgav_constrain.lastdate() ) {
     //    H_LOG( logger, Logger::NOTICE ) << "** Using user-supplied temperature" << std::endl;
-        H_LOG( logger, Logger::NOTICE ) << "** ERROR - Temperature can't currently handle user-supplied temperature" << std::endl;
+        H_LOG( logger, Logger::SEVERE ) << "** ERROR - Temperature can't currently handle user-supplied temperature" << std::endl;
+        H_THROW("User-supplied temperature not yet implemented.")
     }
         
     // Some needed inputs
     int tstep = runToDate - core->getStartDate();
-    double aero_forcing = double(core->sendMessage( M_GETDATA, D_RF_BC ).value( U_W_M2 )) + double(core->sendMessage( M_GETDATA, D_RF_OC ).value( U_W_M2 )) + double(core->sendMessage( M_GETDATA, D_RF_SO2d ).value( U_W_M2 )) + double(core->sendMessage( M_GETDATA, D_RF_SO2i ).value( U_W_M2 ));
+    double aero_forcing =
+        double(core->sendMessage( M_GETDATA, D_RF_BC ).value( U_W_M2 )) + double(core->sendMessage( M_GETDATA, D_RF_OC).value( U_W_M2 )) + 
+        double(core->sendMessage( M_GETDATA, D_RF_SO2d ).value( U_W_M2 )) + double(core->sendMessage( M_GETDATA, D_RF_SO2i ).value( U_W_M2 ));
+
     forcing[tstep] = double(core->sendMessage( M_GETDATA, D_RF_TOTAL ).value( U_W_M2 )) - ( 1.0 - alpha ) * aero_forcing;
-			    
+    
     // Initialize variables for time-stepping through the model
     double DQ1 = 0.0;
     double DQ2 = 0.0;
@@ -410,10 +414,7 @@ void TemperatureComponent::run( const double runToDate ) throw ( h_exception ) {
         heat_interior[0] = 0.0;
     }
 
-    flux_mixed.set( heatflux_mixed[tstep], U_W_M2, 0.0 );
-    flux_interior.set( heatflux_interior[tstep], U_W_M2, 0.0 );
-    heatflux.set( heatflux_mixed[tstep] + fso * heatflux_interior[tstep], U_W_M2, 0.0 );
-    tgav.set( temp[tstep], U_DEGC, 0.0 );
+    setoutputs(tstep);
     H_LOG( logger, Logger::DEBUG ) << " tgav=" << tgav << " in " << runToDate << std::endl;
 }
 
@@ -455,6 +456,12 @@ void TemperatureComponent::reset(double time) throw(h_exception)
     H_THROW("TemperatureComponent::reset : not yet implemented.")
     H_LOG(logger, Logger::NOTICE)
         << getComponentName() << " reset to time= " << time << "\n";
+    // We take a slightly different approach in this component's reset method than we have in other components.  The
+    // temperature component doesn't have its own time counter, and it stores its history in a collection of double
+    // vectors.  Therefore, all we do here is set the unitval versions of that stored data to their values from the
+    // vectors.
+    int tstep = time - core->getStartDate();
+    setoutputs(tstep);
 }
 
 
@@ -472,4 +479,15 @@ void TemperatureComponent::accept( AVisitor* visitor ) {
     visitor->visit( this );
 }
 
+
+void TemperatureComponent::setoutputs(int tstep)
+{
+    flux_mixed.set( heatflux_mixed[tstep], U_W_M2, 0.0 );
+    flux_interior.set( heatflux_interior[tstep], U_W_M2, 0.0 );
+    heatflux.set( heatflux_mixed[tstep] + fso * heatflux_interior[tstep], U_W_M2, 0.0 );
+    tgav.set(temp[tstep], U_DEGC, 0.0);
+    tgaveq.set(temp[tstep], U_DEGC, 0.0); // per comment line 140 of temperature_component.hpp
 }
+
+}
+

--- a/source/components/temperature_component.cpp
+++ b/source/components/temperature_component.cpp
@@ -31,7 +31,7 @@ using namespace std;
 //------------------------------------------------------------------------------
 /*! \brief Constructor
  */
-TemperatureComponent::TemperatureComponent() : internal_Ftot(0.0), last_Ftot(0.0) {
+TemperatureComponent::TemperatureComponent() {
 }
 
 //------------------------------------------------------------------------------

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -146,7 +146,8 @@ unitval CarbonCycleSolver::getData( const std::string& varName,
 
 void CarbonCycleSolver::reset(double time) throw(h_exception)
 {
-    H_THROW("CarbonCycleSolver::reset : not yet implemented.");
+    // Only state maintained by this component is the time counter
+    t = time;
     H_LOG(logger, Logger::NOTICE)
         << getComponentName() << " reset to time= " << time << "\n";
 }

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -283,6 +283,8 @@ void CarbonCycleSolver::run( const double tnew ) throw ( h_exception )
     H_LOG( logger, Logger::NOTICE ) << "ODE solver success at t= " << t <<
     "  last dt= " << dt << std::endl;
     H_LOG( logger, Logger::DEBUG ) << "cvals\terrors\n";
+
+    cmodel->record_state(tnew);
     
     H_LOG( logger, Logger::NOTICE ) << std::endl;
 }
@@ -341,6 +343,8 @@ bool CarbonCycleSolver::run_spinup( const int step ) throw( h_exception )
         t = core->getStartDate();
         H_LOG( logger, Logger::NOTICE ) << "Resetting solver time counter to t= " << t << std::endl;
     }
+
+    cmodel->record_state(double(step));
     
     return spunup;
 }

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -148,6 +148,7 @@ void CarbonCycleSolver::reset(double time) throw(h_exception)
 {
     // Only state maintained by this component is the time counter
     t = time;
+    in_spinup = false;          // reset this in case we will be expected to rerun the spinup.
     H_LOG(logger, Logger::NOTICE)
         << getComponentName() << " reset to time= " << time << "\n";
 }
@@ -221,6 +222,9 @@ void CarbonCycleSolver::failure( int stat, double t0, double tmid ) throw( h_exc
 // documentation is inherited
 void CarbonCycleSolver::run( const double tnew ) throw ( h_exception )
 {
+    if(tnew <= t) {
+        H_LOG(logger, Logger::SEVERE) << "run(): tnew= " << tnew << "   t= " << t << std::endl;
+    }
     H_ASSERT( tnew > t, "solver tnew is not greater than t" );
     
     // Get the initial state data from the box model. c will be filled in
@@ -345,7 +349,9 @@ bool CarbonCycleSolver::run_spinup( const int step ) throw( h_exception )
         H_LOG( logger, Logger::NOTICE ) << "Resetting solver time counter to t= " << t << std::endl;
     }
 
-    cmodel->record_state(double(step));
+    // Record the state as the state at the model start time.  This
+    // will be repeatedly overwritten until the spinup is complete.
+    cmodel->record_state(core->getStartDate());
     
     return spunup;
 }

--- a/source/core/carbon-cycle-solver.cpp
+++ b/source/core/carbon-cycle-solver.cpp
@@ -144,6 +144,15 @@ unitval CarbonCycleSolver::getData( const std::string& varName,
     return returnval;
 }
 
+void CarbonCycleSolver::reset(double time) throw(h_exception)
+{
+    H_THROW("CarbonCycleSolver::reset : not yet implemented.");
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
+
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleSolver::shutDown()

--- a/source/core/core.cpp
+++ b/source/core/core.cpp
@@ -437,6 +437,21 @@ void Core::run(double runtodate) throw ( h_exception ) {
     lastDate = runtodate;
 }
 
+
+void Core::reset(double resetdate)
+{
+    Logger &glog(Logger::getGlobalLogger());
+    H_LOG(glog, Logger::NOTICE) << "Resetting model to t= " << resetdate << endl;
+
+    for(NameComponentIterator it = modelComponents.begin(); it != modelComponents.end(); ++it) {
+        H_LOG(glog, Logger::DEBUG) << "Resetting component: " << it->first << endl;
+        it->second->reset(resetdate);
+    }
+
+    lastDate = resetdate;
+}
+
+
 /*! \brief Shut down all model components 
  *  \details After this function is called no components are valid,
  *           and you must not call run() again.

--- a/source/core/core.cpp
+++ b/source/core/core.cpp
@@ -344,34 +344,41 @@ void Core::prepareToRun(void) throw (h_exception)
     // 5. Spin up the model
     if( do_spinup ) {
         H_LOG( glog, Logger::NOTICE) << "Spinning up model..." << endl;
-        
-        in_spinup = true;
-        bool spunup = false;
-        int step = 0;
-        while( !spunup && ++step<max_spinup ) {
-            spunup = true;
-            for( NameComponentIterator it = modelComponents.begin(); it != modelComponents.end(); ++it )
-                spunup = spunup && ( *it ).second->run_spinup( step );
-
-            // Let visitors attempt to collect data if necessary
-            for( VisitorIterator visitorIt = modelVisitors.begin(); visitorIt != modelVisitors.end(); ++visitorIt ) {
-                if( ( *visitorIt )->shouldVisit( in_spinup, step ) ) {
-                    accept( *visitorIt );
-                }
-            } // for
-        } // while
-        
-        if( spunup ) {
-            H_LOG( glog, Logger::NOTICE) << "Model spun up after " << step << " steps" << endl;
-        } else {
-            H_LOG( glog, Logger::SEVERE) << "Model failed to spin up after " << step << " steps" << endl;
-        }
-        in_spinup = false;
+        run_spinup(); 
     } else {
         H_LOG( glog, Logger::WARNING) << "No model spinup was requested" << endl;
     } // if 
 }
 
+bool Core::run_spinup()
+{
+    in_spinup = true;
+    bool spunup = false;
+    int step = 0;
+    while( !spunup && ++step<max_spinup ) {
+        spunup = true;
+        for( NameComponentIterator it = modelComponents.begin(); it != modelComponents.end(); ++it )
+            spunup = spunup && ( *it ).second->run_spinup( step );
+        
+        // Let visitors attempt to collect data if necessary
+        for( VisitorIterator visitorIt = modelVisitors.begin(); visitorIt != modelVisitors.end(); ++visitorIt ) {
+            if( ( *visitorIt )->shouldVisit( in_spinup, step ) ) {
+                accept( *visitorIt );
+            }
+        } // for
+    } // while
+
+    Logger& glog = Logger::getGlobalLogger();
+    if( spunup ) {
+        H_LOG( glog, Logger::NOTICE) << "Model spun up after " << step << " steps" << endl;
+    } else {
+        H_LOG( glog, Logger::SEVERE) << "Model failed to spin up after " << step << " steps" << endl;
+    }
+    in_spinup = false;
+
+    return spunup;
+}
+    
 //------------------------------------------------------------------------------
 /*! \brief Run the components for one-year time steps through runtodate
  *
@@ -440,13 +447,26 @@ void Core::run(double runtodate) throw ( h_exception ) {
 
 void Core::reset(double resetdate)
 {
+    bool rerun_spinup = false;
     Logger &glog(Logger::getGlobalLogger());
     H_LOG(glog, Logger::NOTICE) << "Resetting model to t= " << resetdate << endl;
+    if(resetdate < getStartDate()) {
+        H_LOG(glog, Logger::NOTICE) << "Requested reset time before start date.  "
+                                    << "Resetting to start date.\n";
+        resetdate = getStartDate();
+
+        if(do_spinup) {
+            rerun_spinup = true;
+            H_LOG(glog, Logger::NOTICE) << "Rerunning spinup.\n";
+        }
+    }
 
     for(NameComponentIterator it = modelComponents.begin(); it != modelComponents.end(); ++it) {
         H_LOG(glog, Logger::DEBUG) << "Resetting component: " << it->first << endl;
         it->second->reset(resetdate);
     }
+    if(rerun_spinup)
+        run_spinup();
 
     lastDate = resetdate;
 }

--- a/source/main-api.cpp
+++ b/source/main-api.cpp
@@ -130,9 +130,8 @@ int main (int argc, char * const argv[]) {
         // because the emissions time series aren't affected by the
         // reset.  We could, however, push new emissions into the
         // model if, for example, we wanted to run a revised scenario.
-        double newt = core.getStartDate() + 5.0;
-        core.reset(newt);
-        for( ; newt<=core.getEndDate(); newt+=5.0) {
+        core.reset(0);          // reset to start and rerun spinup.
+        for(double newt = core.getStartDate()+5.0; newt<=core.getEndDate(); newt+=5.0) {
             core.run(newt);
             unitval temp = core.sendMessage(M_GETDATA, D_GLOBAL_TEMP);
             unitval ca   = core.sendMessage(M_GETDATA, D_ATMOSPHERIC_CO2);

--- a/source/models/carbon-cycle-model.cpp
+++ b/source/models/carbon-cycle-model.cpp
@@ -23,37 +23,5 @@ void CarbonCycleModel::init( Core* core ) {
     H_LOG(logger, Logger::DEBUG) << getComponentName() << " initialized." << std::endl;
 }
 
-//------------------------------------------------------------------------------
-// documentation is inherited
-unitval CarbonCycleModel::sendMessage( const std::string& message,
-                         const std::string& datum,
-                         const message_data info ) throw ( h_exception )
-{
-    H_THROW( "Should not be here yet!" );
-    return unitval();
-}
-
-//------------------------------------------------------------------------------
-// documentation is inherited
-//! \remark The Carbon Cycle Model base class has no settable data.
-void CarbonCycleModel::setData( const std::string& varName,
-                                const message_data& data ) throw (h_exception)
-{
-    H_THROW( "Unknown variable name while parsing " + getComponentName() + ": "
-            + varName );
-}
-
-//------------------------------------------------------------------------------
-// documentation is inherited
-void CarbonCycleModel::prepareToRun() throw(h_exception) {
-    H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
-}
-
-//------------------------------------------------------------------------------
-// documentation is inherited
-void CarbonCycleModel::shutDown() {
-	H_LOG( logger, Logger::DEBUG ) << "goodbye " << getComponentName() << std::endl;
-    logger.close();
-}
 
 }

--- a/source/models/simpleNbox.cpp
+++ b/source/models/simpleNbox.cpp
@@ -451,11 +451,18 @@ unitval SimpleNbox::getData( const std::string& varName,
     return returnval;
 }
 
+void SimpleNbox::reset(double time) throw(h_exception)
+{
+    H_THROW("SimpleNbox::reset : not yet implemented.")
+    H_LOG(logger, Logger::NOTICE)
+        << getComponentName() << " reset to time= " << time << "\n";
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void SimpleNbox::shutDown()
 {
-	H_LOG( logger, Logger::DEBUG ) << "goodbye " << getComponentName() << std::endl;
+    H_LOG( logger, Logger::DEBUG ) << "goodbye " << getComponentName() << std::endl;
     logger.close();
 }
 

--- a/source/models/simpleNbox.cpp
+++ b/source/models/simpleNbox.cpp
@@ -910,6 +910,12 @@ void SimpleNbox::record_state(double t)
     tempferts_tv.set(t, tempferts);
     H_LOG(logger, Logger::DEBUG) << "record_state: recorded tempferts = " << tempferts[SNBOX_DEFAULT_BIOME]
                                  << " at time= " << t << std::endl;
+
+    // ocean model appears to be controlled by the N-box model.  Seems
+    // like it makes swapping out for another model a nightmare, but
+    // that's where we're at.
+    omodel->record_state(t);
+    
 }
 
 }

--- a/source/visitors/csv_outputstream_visitor.cpp
+++ b/source/visitors/csv_outputstream_visitor.cpp
@@ -126,9 +126,14 @@ s << linestamp() << c->getComponentName() << DELIMITER \
 void CSVOutputStreamVisitor::visit( ForcingComponent* c ) {
     if( !core->outputEnabled( c->getComponentName() ) ) return;
     streamsize oldPrecision = csvFile.precision( 4 );
+
+    if(c->currentYear < c->baseyear)
+        return;
+    
+    ForcingComponent::forcings_t  forcings = c->forcings_ts.get(c->currentYear);
     
     // Walk through the forcings map, outputting everything
-    for( ForcingComponent::forcingsIterator it = c->forcings.begin(); it != c->forcings.end(); ++it ) {
+    for( ForcingComponent::forcingsIterator it = forcings.begin(); it != forcings.end(); ++it ) {
         STREAM_UNITVAL( csvFile, c, ( *it ).first, ( *it ).second );
     }
     


### PR DESCRIPTION
Add method `reset` to the public interface of `Core`.  Calling this method causes the entire model to reset its state to a specified (previous) time.  Additionally, resetting to a time prior to the start of the model causes the spinup to be rerun, allowing us to change model parameters and restart the scenario in a state consistent with the new parameters.

Closes #240 