### PR TITLE
BUILD: Use `BH` package to automatically provide Boost libraries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,8 +7,12 @@ Depends: R (>= 3.3)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-LinkingTo: Rcpp
-Imports: Rcpp
+Imports:
+  Rcpp,
+  BH
+LinkingTo:
+  Rcpp,
+  BH
 RoxygenNote: 6.0.1
 Suggests: testthat
 SystemRequirements: Boost C++ libraries

--- a/src/Makevars
+++ b/src/Makevars
@@ -3,9 +3,9 @@
 ##   * BOOSTLIB   : Location of compiled boost libraries
 
 
-PKG_CPPFLAGS = -I../inst/include -I${BOOSTROOT} -DUSE_RCPP 
+PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
 
-PKG_LIBS = -L${BOOSTLIB} -Wl,-rpath ${BOOSTLIB} -lboost_system -lboost_filesystem
+PKG_LIBS = -Wl,-rpath -lboost_system -lboost_filesystem
 
 
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,11 +1,2 @@
-## The following environment variables must be set in .Renvironment:
-##   * BOOSTROOT  : Top level of Boost library directories
-##   * BOOSTLIB   : Location of compiled boost libraries
-
-
 PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
-
 PKG_LIBS = -Wl,-rpath -lboost_system -lboost_filesystem
-
-
-

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -46,7 +46,7 @@ List newcore(String inifile, int loglevel = 0, bool suppresslogging=false)
     try {
         // Check that the configuration file exists. The easiest way to do
         // this is to try to open it.
-        std::ifstream ifs(inifile);      // we'll use this to test if the file exists
+	std::ifstream ifs(inifile.get_cstring());      // we'll use this to test if the file exists
         if(ifs) {
             ifs.close();            // don't actually want to read from it
         }


### PR DESCRIPTION
This removes the need to manually install Boost by depending instead on a well known, widely-used, R-friendly distribution (via the [BH package](https://github.com/eddelbuettel/bh)).

To test, run the following:

```r
devtools::install_github("ashiklom/hector@bh-boost")
```