### PR TITLE
Call `get_cstring` method for reading ini file

### DIFF
--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -46,7 +46,7 @@ List newcore(String inifile, int loglevel = 0, bool suppresslogging=false)
     try {
         // Check that the configuration file exists. The easiest way to do
         // this is to try to open it.
-        std::ifstream ifs(inifile);      // we'll use this to test if the file exists
+	std::ifstream ifs(inifile.get_cstring());      // we'll use this to test if the file exists
         if(ifs) {
             ifs.close();            // don't actually want to read from it
         }


### PR DESCRIPTION
This seems to be necessary to avoid errors like the following, at least on Windows:

```
rcpp_hector.cpp: In function 'Rcpp::List newcore(Rcpp::String, int, bool)':
rcpp_hector.cpp:49:34: error: no matching function for call to 'std::basic_ifstream<char>::basic_ifstream(Rcpp::String&)'
         std::ifstream ifs(inifile);      // we'll use this to test if the file exists
                                  ^
```