### PR TITLE
Specify dependency on Rcpp >=0.12 (current version is 0.12.19)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 LinkingTo: Rcpp
-Imports: Rcpp
+Imports: Rcpp (>= 0.12)
 RoxygenNote: 6.0.1
 Suggests: testthat
 SystemRequirements: Boost C++ libraries


### PR DESCRIPTION
Specifying explicit dependency versions is good practice, and helps make sure we aren't claiming to support ancient versions of Rcpp.