### PR TITLE
Remove boost::filesystem dependency by using R file functions.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,9 +7,8 @@ Depends: R (>= 3.3)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-LinkingTo: Rcpp
-Imports: Rcpp (>= 0.12)
-VignetteBuilder: knitr
+LinkingTo: Rcpp, BH
+Imports: Rcpp (>= 0.12), BH (>= 1.65)
 RoxygenNote: 6.0.1
 Suggests:
     testthat,

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,11 +1,2 @@
-## The following environment variables must be set in .Renvironment:
-##   * BOOSTROOT  : Top level of Boost library directories
-##   * BOOSTLIB   : Location of compiled boost libraries
-
-
-PKG_CPPFLAGS = -I../inst/include -I${BOOSTROOT} -DUSE_RCPP 
-
-PKG_LIBS = -L${BOOSTLIB} -Wl,-rpath ${BOOSTLIB} -lboost_system -lboost_filesystem
-
-
-
+PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
+PKG_LIBS = -Wl,-rpath 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,1 @@
 PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
-PKG_LIBS = -Wl,-rpath 


### PR DESCRIPTION
The only compiled boost library we depended on was `boost::filesystem` (which in turn depends on `boost::system`, also compiled). The only reason we needed it was to check if the CSV file path was absolute, and if not, prepend the directory of the INI file.

By eliminating the boost compiled library dependency (and replacing it with the boost header-only R package `BH`), this means that this should install without issue or any external dependencies on any machine, including Windows. I tested this on a Windows VM and, indeed, it installed just fine.

To test, use the following installation command:

```r
devtools::install_github("ashiklom/hector@new-bh-boost")
```

Here, I replaced calls to `boost::filesystem::path` functions with calls to R's own path manipulation functions (`normalizePath`, `dirname`, and `file.path`) via Rcpp. I also subtly changed the logic to be as follows: If the CSV file path normalizes to an existing file, point to that file. Otherwise, point to the CSV file in the same directory as the INI file. I believe this means that, if you have a CSV file in the same directory as you're running hector (i.e. your R working directory), you can pass that in as a relative path ( (i.e. just the file name) to the INI file and it should work. I'll need to test this out, though.