### PR TITLE
When an input is registered, also register it as a capability.

### DIFF
--- a/inst/include/core.hpp
+++ b/inst/include/core.hpp
@@ -61,7 +61,7 @@ public:
     IModelComponent* getComponentByCapability( const std::string& capabilityName
                                               ) const throw ( h_exception );
     
-    void registerCapability( const std::string& capabilityName, const std::string& componentName
+    void registerCapability(const std::string& capabilityName, const std::string& componentName, bool warndupe=true
                             )  throw ( h_exception );
     
     int checkCapability( const std::string& capabilityName );

--- a/src/bc_component.cpp
+++ b/src/bc_component.cpp
@@ -50,8 +50,6 @@ void BlackCarbonComponent::init( Core* coreptr ) {
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
     core = coreptr;
     
-	// Inform core what data we can provide
-    core->registerCapability( D_EMISSIONS_BC, getComponentName() );
     // Inform core what data we can accept
     core->registerInput(D_EMISSIONS_BC, getComponentName());
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -543,28 +543,47 @@ IModelComponent* Core::getComponentByCapability( const string& capabilityName ) 
 /*! \brief Register a capability as associated with a component.
  *  \param capabilityName The capability of the component to register.
  *  \param componentName The name of the associated component.
+ *  \param warndupe If true (the default) warn when a duplicate capability
+ *                  is declared.  This should only be set to false when being
+ *                  called from registerInput, which sometimes creates duplicates
+ *                  for benign reasons.
  *  \exception h_exception If the componentName was not recognized.
  */
-void Core::registerCapability( const string& capabilityName, const string& componentName
+void Core::registerCapability(const string& capabilityName, const string& componentName, bool warndupe
                               )  throw ( h_exception ){
     H_ASSERT( !isInited, "registerCapability not available after core is initialized")
-    
-    if( componentCapabilities.count( capabilityName ) ) {
+
+    // check whether the capability already exists
+    int ncap = componentCapabilities.count(capabilityName);
+    if(ncap > 0  && warndupe) {
+        // If this capability is a dupe, issue a warning, unless we
+        // have been instructed not to.
         H_LOG( glog, Logger::WARNING ) << componentName << " is declaring capability " << capabilityName << " previously registered" << endl;
     }
-    componentCapabilities.insert( pair<string, string>( capabilityName, componentName ) );
+    else if(ncap == 0) {
+        // Only add the capability if it doesn't already exist.
+        // Adding a duplicate capability has no useful effect anyhow.
+        componentCapabilities.insert( pair<string, string>( capabilityName, componentName ) );
+    }
 }
 
 //------------------------------------------------------------------------------
 /*! \brief Register a component as accepting a certain input
+ *
+ *  \details Associate the input capability with a component.  We also
+ *           implicitly register the capability (under the same name)
+ *           so that other components can read these values.
+ *
  *  \param inputName The name of the input the component can accept
  *  \param componentName The name of the component.
  *  \note It is permissible for more than one component to accept the same
- *        inputs.
+ *        inputs; however, only one of them should allow a corresponding
+ *        capability to be declared.
  */
-void Core::registerInput( const string& inputName, const string& componentName ) {
+void Core::registerInput(const string& inputName, const string& componentName) {
     H_ASSERT( !isInited, "registerInput not available after core is initialized") 
     componentInputs.insert( pair<string, string>( inputName, componentName ) );
+    registerCapability(inputName, componentName, false); 
 } 
 
 //------------------------------------------------------------------------------

--- a/src/oc_component.cpp
+++ b/src/oc_component.cpp
@@ -50,9 +50,7 @@ void OrganicCarbonComponent::init( Core* coreptr ) {
     H_LOG( logger, Logger::DEBUG ) << "hello " << getComponentName() << std::endl;
   	core = coreptr;
 
-    // Inform core what data we can provide
-    core->registerCapability( D_EMISSIONS_OC, getComponentName() );
-    // OC emissions are also an input
+    // Register OC emissions are also an input
     core->registerInput(D_EMISSIONS_OC, getComponentName());
 }
 

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -70,11 +70,6 @@ void SimpleNbox::init( Core* coreptr ) {
     core->registerInput(D_PREINDUSTRIAL_CO2, getComponentName()); 
     core->registerInput(D_BETA, getComponentName());
     core->registerInput(D_Q10_RH, getComponentName());
-    // Allow other code to query the inputs, if desired
-    core->registerCapability(D_FFI_EMISSIONS, getComponentName());
-    core->registerCapability(D_LUC_EMISSIONS, getComponentName());
-    core->registerCapability(D_BETA, getComponentName());
-    core->registerCapability(D_Q10_RH, getComponentName());
 }
 
 //------------------------------------------------------------------------------

--- a/src/so2_component.cpp
+++ b/src/so2_component.cpp
@@ -55,8 +55,6 @@ void SulfurComponent::init( Core* coreptr ) {
     // Inform core what data we can provide
     core->registerCapability( D_NATURAL_SO2, getComponentName() );
     core->registerCapability( D_2000_SO2, getComponentName() );
-    core->registerCapability( D_EMISSIONS_SO2, getComponentName() );
-    core->registerCapability( D_VOLCANIC_SO2, getComponentName() );
     // accept anthro emissions and volcanic emissions as inputs
     core->registerInput(D_EMISSIONS_SO2, getComponentName());
     core->registerInput(D_VOLCANIC_SO2, getComponentName());

--- a/src/temperature_component.cpp
+++ b/src/temperature_component.cpp
@@ -111,11 +111,6 @@ void TemperatureComponent::init( Core* coreptr ) {
     core->registerInput(D_ECS, getComponentName());
     core->registerInput(D_DIFFUSIVITY, getComponentName());
     core->registerInput(D_AERO_SCALE, getComponentName());
-    // Allow parameter values to be queried
-    core->registerCapability(D_ECS, getComponentName());
-    core->registerCapability(D_DIFFUSIVITY, getComponentName());
-    core->registerCapability(D_AERO_SCALE, getComponentName());
-
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Now `registerInput` calls `registerCapability` directly.  Because multiple components can share an input (this only happens between O3 and OH, as far as I can tell), but only one component can register a particular capability, we also provide a way for `registerInput` to suppress the warning message that would otherwise be generated.