### PR TITLE
If building R package, use R functions. Otherwise, use boost::filesystem.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,7 +8,9 @@
 ^LICENSE.md$
 ^changelog.txt$
 ^.travis.yml$
+^appveyor.yml$
 ^.github$
+^wiki/
 
 ## Files supporting stand-alone hector.
 ^Makefile$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,9 +7,8 @@ Depends: R (>= 3.3)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-LinkingTo: Rcpp
-Imports: Rcpp (>= 0.12)
-RoxygenNote: 6.0.1
+LinkingTo: Rcpp, BH
+Imports: Rcpp (>= 0.12), BH (>= 1.65)
 Suggests:
     testthat,
     nleqslv,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/JGCRI/hector.svg?branch=master)](https://travis-ci.org/JGCRI/hector)
+[![Build Status](https://travis-ci.org/JGCRI/hector.svg?branch=master)](https://travis-ci.org/JGCRI/hector) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/4ld4ay2gyg2s8w6w?svg=true)](https://ci.appveyor.com/project/ashiklom/hector)
 
 Hector
 ======

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/JGCRI/hector.svg?branch=master)](https://travis-ci.org/JGCRI/hector) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/4ld4ay2gyg2s8w6w?svg=true)](https://ci.appveyor.com/project/ashiklom/hector)
+[![Build Status](https://travis-ci.org/JGCRI/hector.svg?branch=master)](https://travis-ci.org/JGCRI/hector)
+[![Build status](https://ci.appveyor.com/api/projects/status/2jmhvq7n2ap75u1o/branch/master?svg=true)](https://ci.appveyor.com/project/rplzzz/hector/branch/master)
 
 Hector
 ======

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,11 +1,2 @@
-## The following environment variables must be set in .Renvironment:
-##   * BOOSTROOT  : Top level of Boost library directories
-##   * BOOSTLIB   : Location of compiled boost libraries
-
-
-PKG_CPPFLAGS = -I../inst/include -I${BOOSTROOT} -DUSE_RCPP 
-
-PKG_LIBS = -L${BOOSTLIB} -Wl,-rpath ${BOOSTLIB} -lboost_system -lboost_filesystem
-
-
-
+PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
+PKG_LIBS = -Wl,-rpath 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,1 @@
 PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP 
-PKG_LIBS = -Wl,-rpath 

--- a/src/ini_to_core_reader.cpp
+++ b/src/ini_to_core_reader.cpp
@@ -133,10 +133,12 @@ int INIToCoreReader::valueHandler( void* user, const char* section, const char* 
             // Otherwise, assume that it is pointing to a file in the
             // same directory as the INI file.
             try {
-                // Second argument is "winslash". "\\" (single forward
-                // slash) is the default. Need it here to access the
-                // third argument -- mustWork -- which throws the
-                // error to be caught if the path doesn't exist
+                // Second argument is "winslash", which is only used
+                // on Windows machines and is ignored for Unix-based
+                // systems. "\\" (single backward slash) is the
+                // default. Need it here to access the third argument
+                // -- mustWork -- which throws the error to be caught
+                // if the path doesn't exist
                 csvFileName = Rcpp::as<string>(normalizePath(csvFileName, "\\", true));
             } catch (...) {
                 // Get the full path of the INI file with

--- a/src/ini_to_core_reader.cpp
+++ b/src/ini_to_core_reader.cpp
@@ -23,6 +23,7 @@
 #include <Rcpp.h>
 #else
 #include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
 #endif
 
 #include "core.hpp"
@@ -30,10 +31,6 @@
 #include "ini_to_core_reader.hpp"
 #include "ini.h"
 #include "csv_table_reader.hpp"
-
-#ifndef USE_RCPP
-namespace fs = boost::filesystem;
-#endif
 
 namespace Hector {
   

--- a/src/ini_to_core_reader.cpp
+++ b/src/ini_to_core_reader.cpp
@@ -15,13 +15,25 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
+
+// ANS: If using the R package, use Rcpp to call R's file processing
+// functions. Otherwise (e.g. if building standalone Hector), fall
+// back to boost::filesystem (which needs to be installed).
+#ifdef USE_RCPP
 #include <Rcpp.h>
+#else
+#include <boost/filesystem.hpp>
+#endif
 
 #include "core.hpp"
 #include "message_data.hpp"
 #include "ini_to_core_reader.hpp"
 #include "ini.h"
 #include "csv_table_reader.hpp"
+
+#ifndef USE_RCPP
+namespace fs = boost::filesystem;
+#endif
 
 namespace Hector {
   
@@ -80,11 +92,13 @@ void INIToCoreReader::parse( const string& filename ) throw ( h_exception ) {
 int INIToCoreReader::valueHandler( void* user, const char* section, const char* name,
                                   const char* value )
 {
+    #ifdef USE_RCPP
     // Load R functions for path management
     Rcpp::Environment base("package:base");
     Rcpp::Function normalizePath = base["normalizePath"];
     Rcpp::Function dirname = base["dirname"];
     Rcpp::Function filepath = base["file.path"];
+    #endif
 
     static const string csvFilePrefix = "csv:";
     INIToCoreReader* reader = (INIToCoreReader*)user;
@@ -114,6 +128,10 @@ int INIToCoreReader::valueHandler( void* user, const char* section, const char* 
             // remove the special case identifier to figure out the actual file name
             // to process
             string csvFileName( valueStr.begin() + csvFilePrefix.size(), valueStr.end() );
+            #ifdef USE_RCPP
+            // ANS: This is the algorithm used if Hector is compiled
+	    // as an R package.
+            //
 	    // If the csvFileName normalizes to a real path, use that.
             // Otherwise, assume that it is pointing to a file in the
             // same directory as the INI file.
@@ -129,6 +147,18 @@ int INIToCoreReader::valueHandler( void* user, const char* section, const char* 
                 Rcpp::String parentPath = dirname(normalizePath(reader->iniFilePath));
                 csvFileName = Rcpp::as<string>(filepath(parentPath, csvFileName));
             }
+            #else
+            // ANS:: Algorithm for standalone Hector. Same logic -- if
+            // the given path (absolute or relative) points to a file
+            // that exists, use that. Otherwise, assume that the path
+            // is relative to the INI file's directory. 
+            fs::path csvFilePath( csvFileName );
+            if ( !fs::exists(csvFilePath) ) {
+              fs::path iniFilePath( reader->iniFilePath );
+              fs::path fullPath( iniFilePath.parent_path() / csvFilePath );
+              csvFileName = fullPath.string();
+            }
+            #endif
 
             CSVTableReader tableReader( csvFileName );
             tableReader.process( reader->core, section, nameStr );


### PR DESCRIPTION
(This is a revisit of #267 -- see that discussion for additional context).

This commit removes the dependency on compiled `boost` libraries when installing Hector as an R package. It does this by using `Rcpp` bindings to base R functions to process file paths. This -- combined with the use of the `BH` package to provide Boost headers -- means that the R package version can be installed on _any_ system (including Windows -- looking at you, @cahartin and @kdorheim) with just `devtools::install_github` _without installing any other system dependencies_.

You can test this out by running the following in an R session:

```r
devtools::install_github("ashiklom/hector@windows")
```

I tested this on a clean Windows VM and on AppVeyor, and it seemed to work.

Per the discussion on #267, when Hector is _not_ installed as an R package (technically, when the `USE_RCPP` macro is not defined), it falls back on `boost::filesystem`. Although I haven't tried, it _may_ be possible to build a standalone Hector executable that also uses R instead of Boost, if you add the `-DUSE_RCPP` flag and include the path to the Rcpp library.

Also, note that I slightly modified the algorithm for finding the CSV file relative to the INI file as follows:

- First, check if the path given in the INI file points to an existing file.
- If yes, use the file that it found.
- If no, assume the path is relative to the INI file directory

I did this mainly because base R has no `isAbsolutePath` function (or similar). There is [`R.utils::isAbsolutePath`](https://www.rdocumentation.org/packages/R.utils/versions/2.7.0/topics/isAbsolutePath), which wouldn't be too hard to use, but it's implemented with just a few regexes (which doesn't seem very robust) and it would force us to add another R package dependency.