### PR TITLE
Bugfix and tests for the `simpleNbox` multi-biome feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ src/hector-ext
 src/hector-api
 # Hector logs
 logs/*.*
+*.log
 # OS-specific files
 .DS_Store
 .Trashes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,10 @@ Suggests:
     nleqslv,
     knitr,
     rmarkdown,
-    ggplot2
+    ggplot2,
+    hectortools
+Remotes:
+    jgcri/hectortools
 SystemRequirements: Boost C++ libraries
 Collate:
     'aadoc.R'

--- a/inst/input/api-example.ini
+++ b/inst/input/api-example.ini
@@ -79,7 +79,7 @@ q10_rh=2.45		; 2.0 respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., region will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., region will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/inst/input/hector-gcam.ini
+++ b/inst/input/hector-gcam.ini
@@ -70,7 +70,7 @@ q10_rh=2.0		; respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/inst/input/hector_rcp26.ini
+++ b/inst/input/hector_rcp26.ini
@@ -78,7 +78,7 @@ q10_rh=2.0		; respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/inst/input/hector_rcp45.ini
+++ b/inst/input/hector_rcp45.ini
@@ -78,7 +78,7 @@ q10_rh=2.0		; respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/inst/input/hector_rcp60.ini
+++ b/inst/input/hector_rcp60.ini
@@ -78,7 +78,7 @@ q10_rh=2.0		; respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/inst/input/hector_rcp85.ini
+++ b/inst/input/hector_rcp85.ini
@@ -78,7 +78,7 @@ q10_rh=2.0		; respiration response Q10, unitless
 
 ; Optional biome-specific warming factors
 ; by default, assume 1.0 (i.e., warms as fast as the globe)
-;boreal.warming=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
+;boreal.warmingfactor=1.2	; i.e., biome will warm 1.2 C for every 1 C globally
 
 ; Albedo effect, in W/m2. The model assumes a constant value if nothing specified
 Ftalbedo[1750]=0.0

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -873,7 +873,9 @@ void SimpleNbox::slowparameval( double t, const double c[] )
     }
 
     // Loop over biomes.
-    for( itd = tempfertd.begin(); itd != tempfertd.end(); itd++ ) {
+    // NOTE: This is over `beta` because tempfertd is never
+    // initialized for biomes other than the default.
+    for( itd = beta.begin(); itd != beta.end(); itd++ ) {
         std::string biome(itd->first);
         if( in_spinup ) {
             tempfertd[ biome ] = 1.0;  // no perturbation allowed in spinup

--- a/tests/testthat/test_biome.R
+++ b/tests/testthat/test_biome.R
@@ -4,19 +4,25 @@ test_that("Hector runs with multiple biomes.", {
 
   skip_if_not_installed("hectortools")
 
-  vars <- c(
-    ATMOSPHERIC_CO2(),
-    RF_TOTAL(),
-    GLOBAL_TEMP()
-  )
+  quickrun <- function(ini_list, name) {
+    ini_file <- tempfile()
+    on.exit(file.remove(ini_file), add = TRUE)
+    hectortools::write_ini(ini_list, ini_file)
+    core <- newcore(ini_file, name = name, suppresslogging = TRUE)
+    invisible(run(core))
+    on.exit(shutdown(core), add = TRUE)
+    dates <- seq(2000, 2100)
+    vars <- c(
+      ATMOSPHERIC_CO2(),
+      RF_TOTAL(),
+      GLOBAL_TEMP()
+    )
+    fetchvars(core, dates, vars)
+  }
 
-  dates <- seq(2000, 2100)
   rcp45_file <- system.file("input", "hector_rcp45.ini", package = "hector")
   rcp45 <- hectortools::read_ini(rcp45_file)
-  rcp45_core <- newcore(rcp45_file, name = "default")
-  invisible(run(rcp45_core))
-  rcp45_result <- fetchvars(rcp45_core, dates, vars)
-  invisible(shutdown(rcp45_core))
+  rcp45_result <- quickrun(rcp45, "default")
 
   # Set biome-specific variables
   biome <- modifyList(rcp45, list(simpleNbox = list(
@@ -39,15 +45,21 @@ test_that("Hector runs with multiple biomes.", {
     boreal.q10_rh = 2.0,
     tropical.q10_rh = 2.0
   )))
-  biome_file <- tempfile()
-  hectortools::write_ini(biome, biome_file)
-  teardown(file.remove(biome_file))
-  core <- newcore(biome_file, name = "biome")
-  invisible(run(core))
-  result <- fetchvars(core, dates, vars = vars)
-  invisible(shutdown(core))
+  biome_result <- quickrun(biome, "biome")
 
-  result_diff <- rcp45_result$value - result$value
+  result_diff <- rcp45_result$value - biome_result$value
   diff_summary <- tapply(result_diff, rcp45_result$variable, sum)
   expect_true(all(abs(diff_summary) > 0))
+
+  # Add the warming tag
+  warm_biome <- modifyList(biome, list(simpleNbox = list(
+    boreal.warmingfactor = 2.5,
+    tropical.warmingfactor = 1.0
+  )))
+  warm_biome_result <- quickrun(warm_biome, "warm_biome")
+  default_tgav <- rcp45_result[rcp45_result[["variable"]] == "Tgav",
+                               "value"]
+  warm_tgav <- warm_biome_result[warm_biome_result[["variable"]] == "Tgav",
+                                 "value"]
+  expect_true(mean(default_tgav) < mean(warm_tgav))
 })

--- a/tests/testthat/test_biome.R
+++ b/tests/testthat/test_biome.R
@@ -1,0 +1,53 @@
+context("Running Hector with multiple biomes")
+
+test_that("Hector runs with multiple biomes.", {
+
+  skip_if_not_installed("hectortools")
+
+  vars <- c(
+    ATMOSPHERIC_CO2(),
+    RF_TOTAL(),
+    GLOBAL_TEMP()
+  )
+
+  dates <- seq(2000, 2100)
+  rcp45_file <- system.file("input", "hector_rcp45.ini", package = "hector")
+  rcp45 <- hectortools::read_ini(rcp45_file)
+  rcp45_core <- newcore(rcp45_file, name = "default")
+  invisible(run(rcp45_core))
+  rcp45_result <- fetchvars(rcp45_core, dates, vars)
+  invisible(shutdown(rcp45_core))
+
+  # Set biome-specific variables
+  biome <- modifyList(rcp45, list(simpleNbox = list(
+    veg_c = NULL,
+    boreal.veg_c = 100,
+    tropical.veg_c = 450,
+    detritus_c = NULL,
+    boreal.detritus_c = 15,
+    tropical.detritus_c = 45,
+    soil_c = NULL,
+    boreal.soil_c = 1200,
+    tropical.soil_c = 578,
+    npp_flux0 = NULL,
+    boreal.npp_flux0 = 5.0,
+    tropical.npp_flux0 = 45.0,
+    beta = NULL,
+    boreal.beta = 0.36,
+    tropical.beta = 0.36,
+    q10_rh = NULL,
+    boreal.q10_rh = 2.0,
+    tropical.q10_rh = 2.0
+  )))
+  biome_file <- tempfile()
+  hectortools::write_ini(biome, biome_file)
+  teardown(file.remove(biome_file))
+  core <- newcore(biome_file, name = "biome")
+  invisible(run(core))
+  result <- fetchvars(core, dates, vars = vars)
+  invisible(shutdown(core))
+
+  result_diff <- rcp45_result$value - result$value
+  diff_summary <- tapply(result_diff, rcp45_result$variable, sum)
+  expect_true(all(abs(diff_summary) > 0))
+})


### PR DESCRIPTION
1. In the C++ code, `tempfertd` was never initialized for multiple biomes (unlike the other biome-specific parameters), so looping over it would not produce the currect number of values and would throw a cryptic and catastrophic `map` error at runtime. My fix was to loop over the names of the `beta` value instead during initialization of `tempfertd`, since those are initialized correctly and there will always be as many `beta` values as biomes.

2. In the INI files, the `warmingfactor` tag was mislabeled as just `warming` in the comments.

3. I added a few simple unit tests for multi-biome runs. Basically, these just check to make sure that Hector runs and produces different output when multiple biomes are used.

    Note that these tests rely on the INI read-write functions in the [`hectortools`](https://github.com/jgcri/hectortools) package. I added that package to `Suggests` and added a pointer to it via the `Remotes:` field, which should allow it to be installed from GitHub automatically by `devtools` functions. I also made sure to skip the biome tests (via `testthat::skip_if_not_installed`) if `hectortools` is not available. If y'all think this is offensive or otherwise undesirable, I can save the INI test files as their own files, but I'm reluctant to clutter the repo with more example INI files (note that in this PR, I already had to fix the `warmingfactor` label in 5 different places, and adding more INI files would only make this more irritating and error-prone in the future; see also my comments on #284).