### PR TITLE
Automatically reset hector cores when their past has been altered

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hector
 Title: Run the Hector Simple Climate Model
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre"))
 Description: Provides R bindings for the Hector Simple Climate Model.
 Depends: R (>= 3.3)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -799,21 +799,6 @@ shutdown <- function(core) {
     .Call('_hector_shutdown', PACKAGE = 'hector', core)
 }
 
-#' Run the Hector climate model
-#'
-#' Run Hector up through the specified time.  This function does not return the results
-#' of the run.  To get results, run \code{fetch}.
-#'
-#' @param core Handle to the Hector instance that is to be run.
-#' @param runtodate Date to run to.  The default is to run to the end date configured
-#' in the input file used to initialize the core.
-#' @return The Hector instance handle
-#' @export
-#' @family main user interface functions
-run <- function(core, runtodate = -1.0) {
-    .Call('_hector_run', PACKAGE = 'hector', core, runtodate)
-}
-
 #' Reset a Hector instance to an earlier date
 #'
 #' Resetting the model returns it to its state at a previous time.  If the requested time
@@ -830,6 +815,21 @@ run <- function(core, runtodate = -1.0) {
 #' @export
 reset <- function(core, date = 0) {
     .Call('_hector_reset', PACKAGE = 'hector', core, date)
+}
+
+#' Run the Hector climate model
+#'
+#' Run Hector up through the specified time.  This function does not return the results
+#' of the run.  To get results, run \code{fetch}.
+#'
+#' @param core Handle to the Hector instance that is to be run.
+#' @param runtodate Date to run to.  The default is to run to the end date configured
+#' in the input file used to initialize the core.
+#' @return The Hector instance handle
+#' @export
+#' @family main user interface functions
+run <- function(core, runtodate = -1.0) {
+    .Call('_hector_run', PACKAGE = 'hector', core, runtodate)
 }
 
 #' \strong{getdate}: Get the current date for a Hector instance

--- a/R/hector.R
+++ b/R/hector.R
@@ -83,7 +83,7 @@ runscenario <- function(infile)
 #' @return handle for the Hector instance.
 #' @family main user interface functions
 #' @export
-newcore <- function(inifile, loglevel=0, suppresslogging=FALSE,
+newcore <- function(inifile, loglevel=0, suppresslogging=TRUE,
                     name="unnamed hector core")
 {
     hcore <- newcore_impl(inifile, loglevel, suppresslogging, name)

--- a/R/messages.R
+++ b/R/messages.R
@@ -81,5 +81,9 @@ setvar <- function(core, dates, var, values, unit)
     unit[is.na(unit)] <- '(unitless)'
     sendmessage(core, SETDATA(), var, dates, values, unit)
 
+    if(any(dates <= getdate(core)) || any(is.na(dates))) {
+        core$clean <- FALSE
+    }
+
     invisible(NULL)
 }

--- a/R/messages.R
+++ b/R/messages.R
@@ -82,6 +82,15 @@ setvar <- function(core, dates, var, values, unit)
     sendmessage(core, SETDATA(), var, dates, values, unit)
 
     if(any(dates <= getdate(core)) || any(is.na(dates))) {
+        rdate <- min(dates) -1
+        if(is.na(rdate))
+            rdate <- 0
+
+        if(core$clean)
+            core$reset_date <- rdate
+        else
+            core$reset_date <- min(rdate, core$reset_date)
+
         core$clean <- FALSE
     }
 

--- a/man/newcore.Rd
+++ b/man/newcore.Rd
@@ -4,7 +4,7 @@
 \alias{newcore}
 \title{Create and initialize a new hector instance}
 \usage{
-newcore(inifile, loglevel = 0, suppresslogging = FALSE,
+newcore(inifile, loglevel = 0, suppresslogging = TRUE,
   name = "unnamed hector core")
 }
 \arguments{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1320,18 +1320,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// run
-Environment run(Environment core, double runtodate);
-RcppExport SEXP _hector_run(SEXP coreSEXP, SEXP runtodateSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Environment >::type core(coreSEXP);
-    Rcpp::traits::input_parameter< double >::type runtodate(runtodateSEXP);
-    rcpp_result_gen = Rcpp::wrap(run(core, runtodate));
-    return rcpp_result_gen;
-END_RCPP
-}
 // reset
 Environment reset(Environment core, double date);
 RcppExport SEXP _hector_reset(SEXP coreSEXP, SEXP dateSEXP) {
@@ -1341,6 +1329,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Environment >::type core(coreSEXP);
     Rcpp::traits::input_parameter< double >::type date(dateSEXP);
     rcpp_result_gen = Rcpp::wrap(reset(core, date));
+    return rcpp_result_gen;
+END_RCPP
+}
+// run
+Environment run(Environment core, double runtodate);
+RcppExport SEXP _hector_run(SEXP coreSEXP, SEXP runtodateSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Environment >::type core(coreSEXP);
+    Rcpp::traits::input_parameter< double >::type runtodate(runtodateSEXP);
+    rcpp_result_gen = Rcpp::wrap(run(core, runtodate));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1515,8 +1515,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_hector_HEAT_FLUX", (DL_FUNC) &_hector_HEAT_FLUX, 0},
     {"_hector_newcore_impl", (DL_FUNC) &_hector_newcore_impl, 4},
     {"_hector_shutdown", (DL_FUNC) &_hector_shutdown, 1},
-    {"_hector_run", (DL_FUNC) &_hector_run, 2},
     {"_hector_reset", (DL_FUNC) &_hector_reset, 2},
+    {"_hector_run", (DL_FUNC) &_hector_run, 2},
     {"_hector_getdate", (DL_FUNC) &_hector_getdate, 1},
     {"_hector_sendmessage", (DL_FUNC) &_hector_sendmessage, 6},
     {"_hector_chk_core_valid", (DL_FUNC) &_hector_chk_core_valid, 1},

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -74,6 +74,7 @@ Environment newcore_impl(String inifile, int loglevel, bool suppresslogging, Str
         rv["enddate"] = enddate;
         rv["inifile"] = inifile;
         rv["name"] = name;
+        rv["clean"] = true;
         
         return rv;
     }
@@ -108,34 +109,6 @@ Environment shutdown(Environment core)
 }
 
 
-//' Run the Hector climate model
-//'
-//' Run Hector up through the specified time.  This function does not return the results
-//' of the run.  To get results, run \code{fetch}.
-//'
-//' @param core Handle to the Hector instance that is to be run.
-//' @param runtodate Date to run to.  The default is to run to the end date configured
-//' in the input file used to initialize the core.
-//' @return The Hector instance handle
-//' @export
-//' @family main user interface functions
-// [[Rcpp::export]]
-Environment run(Environment core, double runtodate=-1.0)
-{
-    Hector::Core *hcore = gethcore(core);
-    try {
-        hcore->run(runtodate);
-    }
-    catch(h_exception e) {
-        std::stringstream msg;
-        msg << "Error while running hector:  " << e;
-        Rcpp::stop(msg.str());
-    }
-
-    return core;
-}
-
-
 //' Reset a Hector instance to an earlier date
 //'
 //' Resetting the model returns it to its state at a previous time.  If the requested time
@@ -163,6 +136,48 @@ Environment reset(Environment core, double date=0)
             << " :  " << e;
         Rcpp::stop(msg.str());
     }
+
+    if(date == 0)
+        core["clean"] = true;
+    
+    return core;
+}
+
+
+//' Run the Hector climate model
+//'
+//' Run Hector up through the specified time.  This function does not return the results
+//' of the run.  To get results, run \code{fetch}.
+//'
+//' @param core Handle to the Hector instance that is to be run.
+//' @param runtodate Date to run to.  The default is to run to the end date configured
+//' in the input file used to initialize the core.
+//' @return The Hector instance handle
+//' @export
+//' @family main user interface functions
+// [[Rcpp::export]]
+Environment run(Environment core, double runtodate=-1.0)
+{
+    if(!core["clean"])
+        reset(core);
+
+    Hector::Core *hcore = gethcore(core);
+    if(runtodate > 0 && runtodate < hcore->getCurrentDate()) {
+        std::stringstream msg;
+        msg << "Requested run date " << runtodate << " is prior to the current date of "
+            << hcore->getCurrentDate() << ". Run reset() to reset to an earlier date.";
+        Rcpp::stop(msg.str());
+    }
+
+    try {
+        hcore->run(runtodate);
+    }
+    catch(h_exception e) {
+        std::stringstream msg;
+        msg << "Error while running hector:  " << e;
+        Rcpp::stop(msg.str());
+    }
+
     return core;
 }
 

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -75,6 +75,7 @@ Environment newcore_impl(String inifile, int loglevel, bool suppresslogging, Str
         rv["inifile"] = inifile;
         rv["name"] = name;
         rv["clean"] = true;
+        rv["reset_date"] = 0;
         
         return rv;
     }
@@ -137,7 +138,8 @@ Environment reset(Environment core, double date=0)
         Rcpp::stop(msg.str());
     }
 
-    if(date == 0)
+    double rd = core["reset_date"];
+    if(date <= rd)
         core["clean"] = true;
     
     return core;
@@ -159,7 +161,7 @@ Environment reset(Environment core, double date=0)
 Environment run(Environment core, double runtodate=-1.0)
 {
     if(!core["clean"])
-        reset(core);
+        reset(core, core["reset_date"]);
 
     Hector::Core *hcore = gethcore(core);
     if(runtodate > 0 && runtodate < hcore->getCurrentDate()) {

--- a/tests/testthat/test_parameters.R
+++ b/tests/testthat/test_parameters.R
@@ -51,7 +51,7 @@ test_that('Lowering ECS lowers output Temperature', {
     dd1 <- fetchvars(hc, tdates, GLOBAL_TEMP())
 
     setvar(hc, NA, ECS(), 2.5, 'degC')
-    reset(hc, 0.0)
+    ## make sure this still works with automatic reset.
     run(hc, 2100)
     dd2 <- fetchvars(hc, tdates, GLOBAL_TEMP())
 


### PR DESCRIPTION
This patch differs from the proposals advanced in #hector in two ways.
1. There is still just one single function (`setvar`) for setting variables in the API.  Whether a reset is needed or not is checked by looking at whether the `setvar` call will alter timesteps that have already been run.  If so, the core must reset to the last unchanged date.  Changes to parameters (variables whose time is `NA` are deemed to affect the run at all times and therefore require the spinup to be rerun.
2. The reset is not run immediately.  Instead, the core is marked as needing a reset, and `run` will reset any core so marked before proceeding to run it.  This allows us to set several parameters and only perform the reset and spinup rerun once we've made all the changes we wish to make.
