### PR TITLE
Update version of Boost on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ matrix:
       addons: 
         apt: 
           packages: 
-            - libboost-system1.58-dev
-            - libboost-filesystem1.58-dev
+            - libboost-system-dev
+            - libboost-filesystem-dev
 
       # BOOSTROOT is set to look for header files in the default place
       #where Ubuntu apt will install them --
@@ -41,8 +41,8 @@ matrix:
       addons: 
         apt: 
           packages: 
-            - libboost-system1.58-dev
-            - libboost-filesystem1.58-dev
+            - libboost-system-dev
+            - libboost-filesystem-dev
 
       before_script: 
         - "export BOOSTROOT=/usr/include/x86_64-linux-gnu/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ matrix:
       addons: 
         apt: 
           packages: 
-            - libboost-system1.55-dev
-            - libboost-filesystem1.55-dev
-          sources: 
-            - boost-latest
+            - libboost-system1.58-dev
+            - libboost-filesystem1.58-dev
 
       # BOOSTROOT is set to look for header files in the default place
       #where Ubuntu apt will install them --
@@ -43,20 +41,8 @@ matrix:
       addons: 
         apt: 
           packages: 
-            - libboost-system1.55-dev
-            - libboost-filesystem1.55-dev
-          sources: 
-            - boost-latest
-
-      # BOOSTROOT is set to look for header files in the default place
-      #where Ubuntu apt will install them --
-      #i.e. /usr/include/x86_64-linux-gnu. This is set because the
-      #Makefile has a `-I$(BOOSTROOT)` call.  Similarly, BOOSTLIB is
-      #set to /usr/lib/x86_64-linux-gnu, which is where Ubuntu apt
-      #installs boost by default. It has to be specified in full
-      #because otherwise, Hector's Makefile tries to construct
-      #BOOSTLIB by appending `/lib` to BOOSTROOT, which will not work
-      #here because of the `x86_64-linux-gnu` addition.
+            - libboost-system1.58-dev
+            - libboost-filesystem1.58-dev
 
       before_script: 
         - "export BOOSTROOT=/usr/include/x86_64-linux-gnu/"
@@ -71,13 +57,6 @@ matrix:
 
 
     - language: r
-      addons: 
-        apt: 
-          packages: 
-            - libboost-system1.55-dev
-            - libboost-filesystem1.55-dev
-          sources: 
-            - boost-latest
       cache: packages
 
       # Automatically deploy Hector documentation on the gh-pages


### PR DESCRIPTION
As Travis upgraded to Ubuntu 16 (xenial), the version and source of Boost libraries changed. The new default version is 1.58, and it is not in the core Ubuntu repositories (i.e. does not require a PPA).

Previously, this was causing build errors like the following:

```
Package libboost-filesystem1.55-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
Package libboost-system1.55-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'libboost-system1.55-dev' has no installation candidate
E: Package 'libboost-filesystem1.55-dev' has no installation candidate
```

I also removed the dependencies on Boost libraries from the R test since they have not been required since #267.