### PR TITLE
Eliminate `hectortools` dependency from biome tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,10 +22,7 @@ Suggests:
     rmarkdown,
     ggplot2,
     tidyr (>= 0.7),
-    dplyr (>= 0.7),
-    hectortools
-Remotes:
-    jgcri/hectortools
+    dplyr (>= 0.7)
 SystemRequirements: Boost C++ libraries
 Collate:
     'aadoc.R'

--- a/tests/testthat/test_biome.R
+++ b/tests/testthat/test_biome.R
@@ -2,12 +2,12 @@ context("Running Hector with multiple biomes")
 
 test_that("Hector runs with multiple biomes.", {
 
-  skip_if_not_installed("hectortools")
-
-  quickrun <- function(ini_list, name) {
-    ini_file <- tempfile()
-    on.exit(file.remove(ini_file), add = TRUE)
-    hectortools::write_ini(ini_list, ini_file)
+  quickrun <- function(ini_string, name, ini_file = NULL) {
+    if (is.null(ini_file)) {
+      ini_file <- tempfile()
+      on.exit(file.remove(ini_file), add = TRUE)
+      writeLines(ini_string, ini_file)
+    }
     core <- newcore(ini_file, name = name, suppresslogging = TRUE)
     invisible(run(core))
     on.exit(shutdown(core), add = TRUE)
@@ -21,41 +21,60 @@ test_that("Hector runs with multiple biomes.", {
   }
 
   rcp45_file <- system.file("input", "hector_rcp45.ini", package = "hector")
-  rcp45 <- hectortools::read_ini(rcp45_file)
-  rcp45_result <- quickrun(rcp45, "default")
+  raw_ini <- trimws(readLines(rcp45_file))
+  new_ini <- raw_ini
 
-  # Set biome-specific variables
-  biome <- modifyList(rcp45, list(simpleNbox = list(
-    veg_c = NULL,
-    boreal.veg_c = 100,
-    tropical.veg_c = 450,
-    detritus_c = NULL,
-    boreal.detritus_c = 15,
-    tropical.detritus_c = 45,
-    soil_c = NULL,
-    boreal.soil_c = 1200,
-    tropical.soil_c = 578,
-    npp_flux0 = NULL,
-    boreal.npp_flux0 = 5.0,
-    tropical.npp_flux0 = 45.0,
-    beta = NULL,
-    boreal.beta = 0.36,
-    tropical.beta = 0.36,
-    q10_rh = NULL,
-    boreal.q10_rh = 2.0,
-    tropical.q10_rh = 2.0
-  )))
-  biome_result <- quickrun(biome, "biome")
+  # Remove non-biome-specific variables
+  biome_vars <- c("veg_c", "detritus_c", "soil_c", "npp_flux0",
+                  "beta", "q10_rh")
+  biome_rxp <- paste(biome_vars, collapse = "|")
+  iremove <- grep(sprintf("^(%s) *=", biome_rxp), raw_ini)
+  new_ini <- new_ini[-iremove]
+
+  # Add biome-specific versions of above variables at top of
+  # simpleNbox block
+  isnbox <- grep("^\\[simpleNbox\\]$", new_ini)
+  new_ini <- append(new_ini, c(
+    "boreal.veg_c = 100",
+    "tropical.veg_c = 450",
+    "boreal.detritus_c = 15",
+    "tropical.detritus_c = 45",
+    "boreal.soil_c = 1200",
+    "tropical.soil_c = 578",
+    "boreal.npp_flux0 = 5.0",
+    "tropical.npp_flux0 = 45.0",
+    "boreal.beta = 0.36",
+    "tropical.beta = 0.36",
+    "boreal.q10_rh = 2.0",
+    "tropical.q10_rh = 2.0"
+  ), after = isnbox)
+
+  # Make csv paths absolute (otherwise, they search in the tempfile directory)
+  icsv <- grep("^ *.*?=csv:", new_ini)
+  csv_paths_l <- regmatches(new_ini[icsv],
+                            regexec(".*?=csv:(.*?\\.csv)", new_ini[icsv]))
+  csv_paths <- vapply(csv_paths_l, `[[`, character(1), 2)
+  csv_full_paths <- file.path(dirname(rcp45_file), csv_paths)
+  new_ini_l <- Map(
+    gsub,
+    pattern = csv_paths,
+    replacement = csv_full_paths,
+    x = new_ini[icsv]
+  )
+  new_ini[icsv] <- unlist(new_ini_l, use.names = FALSE)
+
+  biome_result <- quickrun(new_ini, "biome")
+  rcp45_result <- quickrun(NULL, "default", ini_file = rcp45_file)
 
   result_diff <- rcp45_result$value - biome_result$value
   diff_summary <- tapply(result_diff, rcp45_result$variable, sum)
   expect_true(all(abs(diff_summary) > 0))
 
   # Add the warming tag
-  warm_biome <- modifyList(biome, list(simpleNbox = list(
-    boreal.warmingfactor = 2.5,
-    tropical.warmingfactor = 1.0
-  )))
+  warm_biome <- append(new_ini, c(
+    "boreal.warmingfactor = 2.5",
+    "tropical.warmingfactor = 1.0"
+  ), after = isnbox)
   warm_biome_result <- quickrun(warm_biome, "warm_biome")
   default_tgav <- rcp45_result[rcp45_result[["variable"]] == "Tgav",
                                "value"]


### PR DESCRIPTION
Our multi-biome unit tests required my `hectortools` package to read, modify, and write the INI file. It was only `Suggests`-ed, but even so, Travis insisted on installing it during our builds. But `hectortools` itself depends on `hector`, so, to install `hectortools`, Travis actually installed an older version of `hector` from CRAN before installing ours. This was my fault, from PR #285, and while it's not a _major_ problem, the added build delay and the conceptual problem of circular dependency has been irritating me for a while.

This PR performs the same tests, but replaces `hectortools` functions with base-R string manipulation of the INI files.