### PR TITLE
Travis: Don't rebuild docs on CRON jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,6 @@ matrix:
         provider: script
         script: Rscript -e 'pkgdown::deploy_site_github()'
         skip_cleanup: true
+        # Don't rebuild documentation during Travis CRON jobs.
+        on:
+          condition: $TRAVIS_EVENT_TYPE != "cron"


### PR DESCRIPTION
Only rebuild the documentation when the repository actually changes. We don't have to do it every week.

Based on:
- [Conditional deployment](https://docs.travis-ci.com/user/deployment#conditional-releases-with-on)
- [Detecting Travis CRON jobs](https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron)