### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,11 @@ Authors@R: c(person("Robert", "Link",
 	     person("Pralit", "Patel", 
 	        email = "pralit.patel@pnnl.gov", 
 	        role = "ctb",
-	        comment = c(ORCID = "0000-0003-3992-1061")))
+	        comment = c(ORCID = "0000-0003-3992-1061")),
+	     person("Alexey", "Shiklomanov",
+	        email = "alexey.shiklomanov@nasa.gov",
+	        role = "ctb",
+	        comment = c(ORCID = "0000-0003-4022-5979")))
 Description: Provides an R interface for the Hector Simple Climate
     Model. Using this interface you can set up and initialize the model,
     change model parameters and emissions inputs, run Hector, and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,31 @@
 Package: hector
 Title: The Hector Simple Climate Model
 Version: 2.5.0
-Authors@R: c(person("Robert", "Link", email = "robert.link@pnnl.gov", role = c("aut", "cre")),
-	     person("Corinne", "Hartin", email = "corinne.hartin@pnnl.gov", role = "aut"),
-	     person("Ben", "Bond-Lamberty", email = "BondLamberty@pnnl.gov", role = "aut"),
-	     person("Pralit", "Patel", email = "pralit.patel@pnnl.gov", role = "aut"))
+Authors@R: c(person("Robert", "Link", 
+            email = "robert.link@pnnl.gov", 
+            role = "aut",
+            comment = c(ORCID = "0000-0002-7071-248X")),
+	     person("Corinne", "Hartin", 
+	        email = "hartin.corinne@epa.gov", 
+	        role = "ctb",
+	        comment = c(ORCID = "0000-0003-1834-6539")),
+	     person("Ben", "Bond-Lamberty", 
+	        email = "bondlamberty@pnnl.gov", 
+	        role = "ctb", 
+	        comment = c(ORCID = "0000-0001-9525-4633")),
+	     person("Kalyn", "Dorheim", 
+	        email = "kalyn.dorheim@pnnl.gov",
+	        role = "cre",
+	        comment = c(ORCID = "0000-0001-8093-8397")),
+	     person("Pralit", "Patel", 
+	        email = "pralit.patel@pnnl.gov", 
+	        role = "ctb",
+	        comment = c(ORCID = "0000-0003-3992-1061")))
 Description: Provides an R interface for the Hector Simple Climate
-    Model.  Using this interface you can set up and initialize the model,
+    Model. Using this interface you can set up and initialize the model,
     change model parameters and emissions inputs, run Hector, and
-    retrieve hector outputs.
+    retrieve model outputs. Note that the package authors are not
+    identical to the C++ model authors.
 Depends: R (>= 3.3)
 License: GPL-3
 Encoding: UTF-8

--- a/man/hector-package.Rd
+++ b/man/hector-package.Rd
@@ -7,9 +7,9 @@
 \title{hector: The Hector Simple Climate Model}
 \description{
 Provides an R interface for the Hector Simple Climate
-    Model.  Using this interface you can set up and initialize the model,
+    Model. Using this interface you can set up and initialize the model,
     change model parameters and emissions inputs, run Hector, and
-    retrieve hector outputs.
+    retrieve model outputs.
 }
 \details{
 This package allows you to run the Hector Simple Climate Model (SCM) from R
@@ -61,13 +61,18 @@ carbon-cycle model: projections and sensitivities, Biogeosciences, 13,
 \code{\link{shutdown}}, \code{\link{fetchvars}}
 }
 \author{
-\strong{Maintainer}: Robert Link \email{robert.link@pnnl.gov}
+\strong{Maintainer}: Kalyn Dorheim \email{kalyn.dorheim@pnnl.gov} (\href{https://orcid.org/0000-0001-8093-8397}{ORCID})
 
 Authors:
 \itemize{
-  \item Corinne Hartin \email{corinne.hartin@pnnl.gov}
-  \item Ben Bond-Lamberty \email{BondLamberty@pnnl.gov}
-  \item Pralit Patel \email{pralit.patel@pnnl.gov}
+  \item Robert Link \email{robert.link@pnnl.gov} (\href{https://orcid.org/0000-0002-7071-248X}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item Corinne Hartin \email{hartin.corinne@epa.gov} (\href{https://orcid.org/0000-0003-1834-6539}{ORCID}) [contributor]
+  \item Ben Bond-Lamberty \email{bondlamberty@pnnl.gov} (\href{https://orcid.org/0000-0001-9525-4633}{ORCID}) [contributor]
+  \item Pralit Patel \email{pralit.patel@pnnl.gov} (\href{https://orcid.org/0000-0003-3992-1061}{ORCID}) [contributor]
 }
 
 }

--- a/man/hector-package.Rd
+++ b/man/hector-package.Rd
@@ -9,7 +9,8 @@
 Provides an R interface for the Hector Simple Climate
     Model. Using this interface you can set up and initialize the model,
     change model parameters and emissions inputs, run Hector, and
-    retrieve model outputs.
+    retrieve model outputs. Note that the package authors are not
+    identical to the C++ model authors.
 }
 \details{
 This package allows you to run the Hector Simple Climate Model (SCM) from R
@@ -73,6 +74,7 @@ Other contributors:
   \item Corinne Hartin \email{hartin.corinne@epa.gov} (\href{https://orcid.org/0000-0003-1834-6539}{ORCID}) [contributor]
   \item Ben Bond-Lamberty \email{bondlamberty@pnnl.gov} (\href{https://orcid.org/0000-0001-9525-4633}{ORCID}) [contributor]
   \item Pralit Patel \email{pralit.patel@pnnl.gov} (\href{https://orcid.org/0000-0003-3992-1061}{ORCID}) [contributor]
+  \item Alexey Shiklomanov \email{alexey.shiklomanov@nasa.gov} (\href{https://orcid.org/0000-0003-4022-5979}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
So the Hector package DESCRIPTION file needs updating:
* Given that @rplzzz has moved on but this is PNNL property, I propose changing the package maintainer ("cre") to @kdorheim , who is one of two repo admins
* However, as far as I know the original package code was almost entirely Robert's work. To reflect this I've changed him to be the only "aut" (author), while the rest of us are "ctb" (contributors). Does this make sense to folks? 
* Updated Corinne's email
* Added @ashiklom as a contributor
* Added ORCID IDs for all
* Tweaked language
