### PR TITLE
Load a stable version of pkgdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,8 @@ matrix:
       # Automatically deploy Hector documentation on the gh-pages
       # branch. This is based on this guide from `pkgdown`:
       # https://pkgdown.r-lib.org/reference/deploy_site_github.html
-      before_deploy: Rscript -e 'remotes::install_cran("pkgdown")'
+      # Import a stable version of the pkgdown.
+      before_deploy: Rscript -e 'remotes::install_github("r-lib/pkgdown@v1.6.0")'
       deploy:
         provider: script
         script: Rscript -e 'pkgdown::deploy_site_github()'


### PR DESCRIPTION
**Describe development**
Trying to get Hector to build on `travis` and to get the `pkgdown` documentation to generate. 


**Type of development** 
PATCH: do not expect a change in behavior 