### PR TITLE
Fix typo in makefile.standalone re LDFLAGS and -Wl,-rpath

### DIFF
--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -6,7 +6,7 @@ CFLAGS   = -g $(INCLUDES) $(OPTFLAGS) -MMD
 INCLUDES = -I"$(BOOSTROOT)" -I"$(HDRDIR)"
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
 OPTFLAGS = -O3
-LDFLAGS	 = $(CXXPROF) -L"$(BOOSTLIB)" -L. -Wl,-rpath "$(BOOSTLIB)"
+LDFLAGS	 = $(CXXPROF) -L"$(BOOSTLIB)" -L. -Wl,-rpath,"$(BOOSTLIB)"
 
 export CXXFLAGS OPTFLAGS
 


### PR DESCRIPTION
See issue ticket #403
The original had a space between 
-Wl,-rpath and $(BOOSTLIB)
This causes the linker to get a -rpath without an argument, and the
$(BOOSTLIB) is passed as an argument to the compiler.

What is wanted is either
-Wl,-rpath,$(BOOSTLIB)
or
-Wl,-rpath -Wl,$(BOOSTLIB)
to prevent linker from complaining about -rpath w/out an argument.