### PR TITLE
Eliminate all clang warnings in the Hector build

### DIFF
--- a/src/carbon-cycle-solver.cpp
+++ b/src/carbon-cycle-solver.cpp
@@ -15,7 +15,12 @@
 
 #include <math.h>
 #include <string>
+
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/numeric/odeint.hpp>
+#pragma clang diagnostic pop
 
 #include "carbon-cycle-solver.hpp"
 #include "avisitor.hpp"

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -557,7 +557,7 @@ void Core::registerCapability(const string& capabilityName, const string& compon
     H_ASSERT( !isInited, "registerCapability not available after core is initialized")
 
     // check whether the capability already exists
-    int ncap = componentCapabilities.count(capabilityName);
+    int ncap = (int)componentCapabilities.count(capabilityName);
     if(ncap > 0  && warndupe) {
         // If this capability is a dupe, issue a warning, unless we
         // have been instructed not to.
@@ -568,7 +568,6 @@ void Core::registerCapability(const string& capabilityName, const string& compon
         // Adding a duplicate capability has no useful effect anyhow.
         componentCapabilities.insert( pair<string, string>( capabilityName, componentName ) );
         H_LOG(glog, Logger::DEBUG) << capabilityName << " registered to component " << componentName << "\n";
-
     }
 }
 
@@ -731,7 +730,7 @@ std::vector<Core *> Core::core_registry;
 int Core::mkcore(bool logtofile, Logger::LogLevel loglvl, bool logtoscrn)
 {
     core_registry.push_back(new Core(loglvl, logtoscrn, logtofile));
-    return core_registry.size() - 1;
+    return (int)core_registry.size() - 1;
 }
 
 /*! Get a core by index

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -13,7 +13,12 @@
  */
 
 #include <fstream>
+
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/lexical_cast.hpp>
+#pragma clang diagnostic pop
 
 #include "dummy_model_component.hpp"
 #include "forcing_component.hpp"

--- a/src/csv_table_reader.cpp
+++ b/src/csv_table_reader.cpp
@@ -13,7 +13,13 @@
  */
 
 #include <vector>
+
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/lexical_cast.hpp>
+#pragma clang diagnostic pop
+
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <errno.h>

--- a/src/forcing_component.cpp
+++ b/src/forcing_component.cpp
@@ -12,7 +12,12 @@
  *
  */
 
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/array.hpp>
+#pragma clang diagnostic pop
+
 #include "forcing_component.hpp"
 #include "avisitor.hpp"
 

--- a/src/ocean_csys.cpp
+++ b/src/ocean_csys.cpp
@@ -24,7 +24,13 @@
  */
 
 #include <math.h>
+
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/math/tools/polynomial.hpp>
+#pragma clang diagnostic pop
+
 #include <boost/math/tools/roots.hpp>
 
 #include "h_exception.hpp"

--- a/src/oceanbox.cpp
+++ b/src/oceanbox.cpp
@@ -275,7 +275,7 @@ void oceanbox::compute_fluxes( const unitval current_Ca, const double yf, const 
             closs_total = closs_total + compute_connection_flux( i, yf );
         } // for i
 
-        if( 0 /* osc */ ) {
+        if( /* DISABLES CODE */ (0) /* osc */ ) {
             const double mean_past_loss = vectorHistoryMean( carbonLossHistory, 10 );
             unstable_box_flux_adjust = mean_past_loss / closs_total.value( U_PGC );
             

--- a/src/temperature_component.cpp
+++ b/src/temperature_component.cpp
@@ -12,7 +12,12 @@
  *
  */
 
+// some boost headers generate warnings under clang; not our problem, ignore
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/lexical_cast.hpp>
+#pragma clang diagnostic pop
+
 #include <cmath>
 #include <limits>
 


### PR DESCRIPTION
[Clang](https://clang.llvm.org) generates quite a few unneeded (from our pov) warnings when building Hector, which is not ideal—it makes it hard to see more serious issues. This PR
* Tells clang to ignore all warnings generated by boost headers; they're not our problem.
* Explicitly marks dead code in `oceanbox.cpp`, removing another warning.
* Adds explicit casts in `core.cpp` to get rid of the rest.

After this there are zero warnings.