### PR TITLE
Remove throw() specifications

### DIFF
--- a/inst/include/bc_component.hpp
+++ b/inst/include/bc_component.hpp
@@ -39,16 +39,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -57,7 +57,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     //! Emissions time series
     tseries<unitval> BC_emissions;

--- a/inst/include/carbon-cycle-solver.hpp
+++ b/inst/include/carbon-cycle-solver.hpp
@@ -108,7 +108,7 @@ private:
     // A functor to provide callbacks for the ODE solver. 
     struct ODEEvalFunctor {
         ODEEvalFunctor( CarbonCycleModel* cmodel, double* time ):modelptr(cmodel), t(time) { }
-        void operator()( const std::vector<double>& y, std::vector<double>& dydt, double t ) throw( bad_derivative_exception );
+        void operator()( const std::vector<double>& y, std::vector<double>& dydt, double t );
         void operator()( const std::vector<double>& y, double t );
         CarbonCycleModel* modelptr;
         double* t;

--- a/inst/include/carbon-cycle-solver.hpp
+++ b/inst/include/carbon-cycle-solver.hpp
@@ -61,18 +61,18 @@ public:
     
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
     
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
     
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
     
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
     
-    virtual bool run_spinup( const int step ) throw ( h_exception );
+    virtual bool run_spinup( const int step );
     
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
     
@@ -82,7 +82,7 @@ public:
     
 private:
     virtual unitval getData( const std::string& varName,
-                            const double valueIndex ) throw ( h_exception );
+                            const double valueIndex );
     
     //! Number of variables to integrate
     int nc;
@@ -114,7 +114,7 @@ private:
         double* t;
     };
     
-    void failure( int stat, double t0, double tmid ) throw( h_exception );
+    void failure( int stat, double t0, double tmid );
     
     bool in_spinup;
     

--- a/inst/include/ch4_component.hpp
+++ b/inst/include/ch4_component.hpp
@@ -38,16 +38,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -56,7 +56,7 @@ public:
 
 	private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
      //! emissions time series
     tseries<unitval> CH4_emissions;
     tseries<unitval> CH4;  // CH4 concentrations, ppbv CH4

--- a/inst/include/core.hpp
+++ b/inst/include/core.hpp
@@ -44,13 +44,13 @@ public:
     void init();
 
     void setData( const std::string& componentName, const std::string& varName,
-                  const message_data& data ) throw ( h_exception );
+                  const message_data& data );
 
     void addVisitor( AVisitor* visitor );
 
-    void prepareToRun() throw ( h_exception );
+    void prepareToRun();
 
-    void run(double runtodate=-1.0) throw ( h_exception );
+    void run(double runtodate=-1.0);
 
     void reset(double resetdate);
 
@@ -59,10 +59,10 @@ public:
     Logger &getGlobalLogger() {return glog;}
 
     IModelComponent* getComponentByCapability( const std::string& capabilityName
-                                              ) const throw ( h_exception );
+                                              ) const;
 
     void registerCapability(const std::string& capabilityName, const std::string& componentName, bool warndupe=true
-                            )  throw ( h_exception );
+                            ) ;
 
     int checkCapability( const std::string& capabilityName );
 
@@ -70,11 +70,11 @@ public:
     void registerInput(const std::string &inputName, const std::string &componentName);
 
     unitval sendMessage( const std::string& message,
-                        const std::string& datum ) throw ( h_exception );
+                        const std::string& datum );
 
     unitval sendMessage( const std::string& message,
                         const std::string& datum,
-                        const message_data& info ) throw ( h_exception );
+                        const message_data& info );
 
     double getStartDate() const { return startDate; };
     double getEndDate() const { return endDate; };
@@ -83,7 +83,7 @@ public:
     bool inSpinup() const { return in_spinup; };
     bool outputEnabled( std::string componentName ) { return std::find( disabledOutputComponents.begin(),
                 disabledOutputComponents.end(), componentName) == disabledOutputComponents.end(); }
-    void addModelComponent( IModelComponent* modelComponent ) throw ( h_exception );
+    void addModelComponent( IModelComponent* modelComponent );
 
     // IVisitable methods
     virtual void accept( AVisitor* visitor );
@@ -91,7 +91,7 @@ public:
     static double undefinedIndex();
 
     IModelComponent* getComponentByName( const std::string& componentName
-                                        ) const throw ( h_exception );
+                                        ) const;
 
     //! Manage cores in the global registry
     static int mkcore(bool logtofile=false,

--- a/inst/include/csv_table_reader.hpp
+++ b/inst/include/csv_table_reader.hpp
@@ -40,11 +40,11 @@ class Core;
  */
 class CSVTableReader {
 public:
-    CSVTableReader( const std::string& fileName ) throw ( h_exception );
+    CSVTableReader( const std::string& fileName );
     ~CSVTableReader();
 
     void process( Core* core, const std::string& componentName,
-                  const std::string& varName ) throw ( h_exception );
+                  const std::string& varName );
 
 private:
     //! The file name to read data from.  Kept around for error reporting.

--- a/inst/include/dependency_finder.hpp
+++ b/inst/include/dependency_finder.hpp
@@ -55,7 +55,7 @@ public:
     DependencyFinder();
     bool addDependency( const std::string& aObjectName,
                         const std::string& aDependency );
-    void createOrdering() throw ( h_exception );
+    void createOrdering();
     const std::vector<std::string>& getOrdering() const;
 private:
     void removeDependency( const size_t aObject, const size_t aDependency );

--- a/inst/include/dummy_model_component.hpp
+++ b/inst/include/dummy_model_component.hpp
@@ -44,16 +44,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
 
@@ -62,7 +62,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double valueIndex ) throw ( h_exception );
+                            const double valueIndex );
 
     //! input var
     double slope;

--- a/inst/include/forcing_component.hpp
+++ b/inst/include/forcing_component.hpp
@@ -43,16 +43,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
 
@@ -65,7 +65,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double valueIndex ) throw ( h_exception );
+                            const double valueIndex );
 
     //! Base year forcings
     forcings_t baseyear_forcings;

--- a/inst/include/h_exception.hpp
+++ b/inst/include/h_exception.hpp
@@ -40,7 +40,7 @@ class h_exception : public std::exception {
                 std::string file_p, int linenum_p)
             : msg(msg_p), func(func_p), file(file_p), linenum(linenum_p) {
     }
-    virtual ~h_exception() throw() {}
+    virtual ~h_exception() {}
     inline std::string get_filename() const {
         return extractFilename(file);
     }

--- a/inst/include/h_reader.hpp
+++ b/inst/include/h_reader.hpp
@@ -31,7 +31,7 @@ class h_reader {
 public:
     h_reader( std::string fname, readertype_t style, bool doparse=true );
     virtual ~h_reader() {delete reader;}
-    void parse() throw( h_exception );
+    void parse();
     std::string get_string( std::string section, std::string name, std::string defaultvalue );
     double get_number( std::string section, std::string name, double defaultvalue );
 private:

--- a/inst/include/halocarbon_component.hpp
+++ b/inst/include/halocarbon_component.hpp
@@ -43,16 +43,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -61,7 +61,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double valueIndex ) throw ( h_exception );
+                            const double valueIndex );
 
     //! Who are we?
     std::string myGasName;

--- a/inst/include/imodel_component.hpp
+++ b/inst/include/imodel_component.hpp
@@ -62,7 +62,7 @@ public:
      */
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception ) = 0;
+                                const message_data info=message_data() ) = 0;
 
     //------------------------------------------------------------------------------
     /*! \brief Sets the variable specified by varName with the given data.
@@ -83,7 +83,7 @@ public:
      *                         value to the appropriate type.
      */
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception ) = 0;
+                          const message_data& data ) = 0;
 
     //------------------------------------------------------------------------------
     /*! \brief A notification that all data are set and the component should prepare to run.
@@ -96,7 +96,7 @@ public:
      *              additional information from it.
      *  \exception h_exception If there was any inconsistencies with input data.
      */
-    virtual void prepareToRun() throw ( h_exception ) = 0;
+    virtual void prepareToRun() = 0;
 
     //------------------------------------------------------------------------------
     /*! \brief Run the component up to the given date.
@@ -110,7 +110,7 @@ public:
      *       initialization.
      *  \exception h_exception If an error occurred for any reason while running.
      */
-    virtual void run( const double runToDate ) throw ( h_exception ) = 0;
+    virtual void run( const double runToDate ) = 0;
 
     //------------------------------------------------------------------------------
     /*! \brief Run the component in spinup mode.
@@ -123,7 +123,7 @@ public:
      *  \return     A bool indicating whether the component is spun up.
      *  \exception  h_exception If an error occurred for any reason while running.
      */
-    virtual bool run_spinup( const int step ) throw ( h_exception ) { return true; }
+    virtual bool run_spinup( const int step ) { return true; }
 
     //------------------------------------------------------------------------------
     /*! \brief Reset the component's state to what it was at some previous time.
@@ -153,7 +153,7 @@ public:
      *  \param date Date to which to reset component state
      *  \exception h_exception If unable to perform the reset.
      */
-    virtual void reset(double time) throw(h_exception) = 0;
+    virtual void reset(double time) = 0;
 
     //------------------------------------------------------------------------------
     /*! \brief We will no longer attempt to run the model; perform any cleanup.
@@ -181,7 +181,7 @@ private:
      *                         value to the appropriate type.
      */
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception ) = 0;
+                            const double date ) = 0;
 };
 
 // Inline methods

--- a/inst/include/ini_to_core_reader.hpp
+++ b/inst/include/ini_to_core_reader.hpp
@@ -36,7 +36,7 @@ class INIToCoreReader {
     INIToCoreReader( Core* core );
     ~INIToCoreReader();
 
-    void parse( const std::string& filename ) throw ( h_exception );
+    void parse( const std::string& filename );
 
     private:
     //! Weak reference to a Core object that will handle parsed values

--- a/inst/include/logger.hpp
+++ b/inst/include/logger.hpp
@@ -100,12 +100,12 @@ public:
     ~Logger();
 
     void open( const std::string& logName, bool echoToScreen,
-               bool echoToFile, LogLevel minLogLevel ) throw ( h_exception );
+               bool echoToFile, LogLevel minLogLevel );
 
     bool shouldWrite( const LogLevel writeLevel ) const;
 
     std::ostream& write( const LogLevel writeLevel,
-                        const std::string& functionInfo ) throw ( h_exception );
+                        const std::string& functionInfo );
 
     void close();
 

--- a/inst/include/message_data.hpp
+++ b/inst/include/message_data.hpp
@@ -60,7 +60,7 @@ struct message_data {
      *      - The unitval units do not match the expected units.
      *      - The value string could not be parsed.
      */
-    unitval getUnitval(const unit_types& expectedUnits, const bool strict = false) const throw ( h_exception ) {
+    unitval getUnitval(const unit_types& expectedUnits, const bool strict = false) const {
         if(isVal) {
             if (strict) {
                 H_ASSERT( value_unitval.units() == expectedUnits, "Units: "+value_unitval.unitsName()+" do not match expected: "+unitval::unitsName( expectedUnits ) );

--- a/inst/include/n2o_component.hpp
+++ b/inst/include/n2o_component.hpp
@@ -39,16 +39,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -57,7 +57,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     unitval N0;    //! preindustrial N2O, ppbv N2O
     unitval UC_N2O;  //! conversion from emissions to concentration

--- a/inst/include/o3_component.hpp
+++ b/inst/include/o3_component.hpp
@@ -38,16 +38,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -57,7 +57,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     //! Current ozone concentration, relative to preindustrial, Dobson units
     unitval PO3;

--- a/inst/include/oc_component.hpp
+++ b/inst/include/oc_component.hpp
@@ -39,16 +39,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -57,7 +57,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     //! Emissions time series
     tseries<unitval> OC_emissions;

--- a/inst/include/ocean_component.hpp
+++ b/inst/include/ocean_component.hpp
@@ -50,18 +50,18 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual bool run_spinup( const int step ) throw ( h_exception );
+    virtual bool run_spinup( const int step );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -75,11 +75,11 @@ public:
     void stashCValues( double t, const double c[] );
     void record_state(double t);
 
-    void run1( const double runToDate ) throw ( h_exception );
+    void run1( const double runToDate );
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     /*****************************************************************
      * State variables for the component

--- a/inst/include/oh_component.hpp
+++ b/inst/include/oh_component.hpp
@@ -40,16 +40,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
 
@@ -59,7 +59,7 @@ public:
 
    private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
      //! emissions time series
     tseries<unitval> CO_emissions;
     tseries<unitval> NOX_emissions;

--- a/inst/include/onelineocean_component.hpp
+++ b/inst/include/onelineocean_component.hpp
@@ -40,16 +40,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -58,7 +58,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     tseries<unitval> total_cflux;        //!< Ocean-to-atmosphere flux, PgC/yr
     tseries<unitval> ocean_c;            //!< Total C in the ocean, PgC

--- a/inst/include/simpleNbox.hpp
+++ b/inst/include/simpleNbox.hpp
@@ -53,18 +53,18 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual bool run_spinup( const int step ) throw ( h_exception );
+    virtual bool run_spinup( const int step );
 
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
 
@@ -84,7 +84,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     // typedefs for two map types, to make things easier
     // TODO: these should probably be defined in h_util.hpp or someplace similar?
@@ -203,7 +203,7 @@ private:
     /*****************************************************************
      * Private helper functions
      *****************************************************************/
-    void sanitychecks() throw( h_exception );           //!< performs mass-balance and other checks
+    void sanitychecks();                                //!< performs mass-balance and other checks
     unitval sum_map( unitval_stringmap pool ) const;    //!< sums a unitval map (collection of data)
     double sum_map( double_stringmap pool ) const;      //!< sums a double map (collection of data)
     void log_pools( const double t );                   //!< prints pool status to the log file

--- a/inst/include/slr_component.hpp
+++ b/inst/include/slr_component.hpp
@@ -43,16 +43,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& ) throw ( h_exception );
+                          const message_data& );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -65,7 +65,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double valueIndex ) throw ( h_exception );
+                            const double valueIndex );
 
     tseries<unitval>	sl_rc;			//!< sea level rate of change, cm/yr
     tseries<unitval>	slr;			//!< sea level rise, cm

--- a/inst/include/so2_component.hpp
+++ b/inst/include/so2_component.hpp
@@ -39,16 +39,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double time) throw(h_exception);
+    virtual void reset(double time);
 
     virtual void shutDown();
 
@@ -61,7 +61,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
 
     //! Emissions time series
 

--- a/inst/include/temperature_component.hpp
+++ b/inst/include/temperature_component.hpp
@@ -49,16 +49,16 @@ public:
 
     virtual unitval sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info=message_data() ) throw ( h_exception );
+                                const message_data info=message_data() );
 
     virtual void setData( const std::string& varName,
-                          const message_data& data ) throw ( h_exception );
+                          const message_data& data );
 
-    virtual void prepareToRun() throw ( h_exception );
+    virtual void prepareToRun();
 
-    virtual void run( const double runToDate ) throw ( h_exception );
+    virtual void run( const double runToDate );
 
-    virtual void reset(double date) throw(h_exception);
+    virtual void reset(double date);
 
     virtual void shutDown();
 
@@ -67,7 +67,7 @@ public:
 
 private:
     virtual unitval getData( const std::string& varName,
-                            const double date ) throw ( h_exception );
+                            const double date );
     void invert_1d_2x2_matrix( double * x, double * y);
     void setoutputs(int tstep);
 

--- a/inst/include/tseries.hpp
+++ b/inst/include/tseries.hpp
@@ -44,8 +44,8 @@ public:
     tseries();
 
     void set( double, T_data );
-    T_data get( double ) const throw( h_exception );
-    T_data get_deriv( double ) const throw( h_exception );
+    T_data get( double ) const;
+    T_data get_deriv( double ) const;
     bool exists( double ) const;
 
     double firstdate() const;
@@ -81,7 +81,7 @@ struct interp_helper {
     static void error_check( const std::map<double, T_data>& userData,
                              h_interpolator& interpolator, std::string name,
                              bool& isDirty, bool endinterp_allowed,
-                             const double index ) throw( h_exception )
+                             const double index )
     {
         H_ASSERT( userData.size() > 1, "time series data(" + name + ") must have size>1" );
 
@@ -110,7 +110,7 @@ struct interp_helper {
     static T_data interp( const std::map<double, T_data>& userData,
                           h_interpolator& interpolator, std::string name,
                           bool& isDirty, bool endinterp_allowed,
-                          const double index ) throw( h_exception )
+                          const double index )
     {
         error_check( userData, interpolator, name, isDirty, endinterp_allowed, index );
 
@@ -119,7 +119,7 @@ struct interp_helper {
     static T_data calc_deriv( const std::map<double, T_data>& userData,
                               h_interpolator& interpolator, std::string name,
                               bool& isDirty, bool endinterp_allowed,
-                              const double index ) throw( h_exception )
+                              const double index )
     {
         error_check( userData, interpolator, name, isDirty, endinterp_allowed, index );
 
@@ -144,7 +144,7 @@ struct interp_helper<unitval> {
     static void error_check( const std::map<double, T_unit_type>& userData,
                              h_interpolator& interpolator, std::string name,
                              bool& isDirty, bool endinterp_allowed,
-                             const double index ) throw( h_exception )
+                             const double index )
     {
         H_ASSERT( userData.size() > 1, "time series data (" + name + ") must have size>1" );
 
@@ -173,7 +173,7 @@ struct interp_helper<unitval> {
     static T_unit_type interp( const std::map<double, T_unit_type>& userData,
                                h_interpolator& interpolator, std::string name,
                                bool& isDirty, bool endinterp_allowed,
-                               const double index ) throw( h_exception )
+                               const double index )
     {
         error_check( userData, interpolator, name, isDirty, endinterp_allowed, index );
 
@@ -182,7 +182,7 @@ struct interp_helper<unitval> {
     static T_unit_type calc_deriv( const std::map<double, T_unit_type>& userData,
                                    h_interpolator& interpolator, std::string name,
                                    bool& isDirty, bool endinterp_allowed,
-                                   const double index ) throw( h_exception )
+                                   const double index )
     {
         error_check( userData, interpolator, name, isDirty, endinterp_allowed, index );
 
@@ -244,7 +244,7 @@ bool tseries<T_data>::exists( double t ) const {
  *  as a constant (i.e, return the single value that we have).
  */
 template <class T_data>
-T_data tseries<T_data>::get( double t ) const throw( h_exception ) {
+T_data tseries<T_data>::get( double t ) const {
     if(mapdata.size() == 1)
         return mapdata.begin()->second;
     typename std::map<double,T_data>::const_iterator itr = mapdata.find( t );
@@ -268,7 +268,7 @@ T_data tseries<T_data>::get( double t ) const throw( h_exception ) {
  *
  */
 template <class T_data>
-T_data tseries<T_data>::get_deriv( double t ) const throw( h_exception ) {
+T_data tseries<T_data>::get_deriv( double t ) const {
     if(mapdata.size() == 1) {
         H_THROW( "More than one data point needed to calculate a derivative" );
     }

--- a/inst/include/tvector.hpp
+++ b/inst/include/tvector.hpp
@@ -47,8 +47,8 @@ class tvector {
 public:
 
     void set(double, const T_data &);
-    const T_data &get(double) const throw( h_exception );
-    T_data &get(double) throw(h_exception); // allow modify-in-place
+    const T_data &get(double) const;
+    T_data &get(double); // allow modify-in-place
     bool exists( double ) const;
 
     // indexing operators: the const version is just syntactic sugar
@@ -56,7 +56,7 @@ public:
     // requested object doesn't exist, it default constructs it,
     // assigns the new object, and returns the reference to the newly
     // created object.  This allows you to write tvec[t] = xx.
-    const T_data &operator[](double t) const throw(h_exception) {
+    const T_data &operator[](double t) const {
         return get(t);
     }
     T_data &operator[](double t);
@@ -105,7 +105,7 @@ bool tvector<T_data>::exists( double t ) const {
  *  If no value exists, raise an exception.
  */
 template <class T_data>
-const T_data &tvector<T_data>::get( double t ) const throw( h_exception ) {
+const T_data &tvector<T_data>::get( double t ) const {
     typename std::map<double,T_data>::const_iterator itr = mapdata.find( round(t) );
     if( itr != mapdata.end() )
         return (*itr).second;
@@ -122,7 +122,7 @@ const T_data &tvector<T_data>::get( double t ) const throw( h_exception ) {
  * non-const reference, allowing an object to be modified in place.
  */
 template <class T_data>
-T_data &tvector<T_data>::get( double t ) throw( h_exception ) {
+T_data &tvector<T_data>::get( double t ) {
     typename std::map<double,T_data>::iterator itr = mapdata.find( round(t) );
     if( itr != mapdata.end() )
         return itr->second;

--- a/inst/include/unitval.hpp
+++ b/inst/include/unitval.hpp
@@ -135,20 +135,20 @@ class unitval {
 
 public:
     static std::string unitsName( const unit_types );
-    static unit_types parseUnitsName( const std::string& ) throw( h_exception );
+    static unit_types parseUnitsName( const std::string& );
 
     unitval();
     unitval( double, unit_types );
 
     void set( double, unit_types, double );
 
-    double value( unit_types ) const throw( h_exception );
+    double value( unit_types ) const;
     unit_types units() const { return valUnits; };
     std::string unitsName() const { return unitsName( valUnits ); };
-    void expecting_unit( const unit_types& ) throw( h_exception );
+    void expecting_unit( const unit_types& );
 
-    static unitval parse_unitval( const std::string&, const unit_types& ) throw( h_exception );
-    static unitval parse_unitval( const std::string&, const std::string&, const unit_types& ) throw( h_exception );
+    static unitval parse_unitval( const std::string&, const unit_types& );
+    static unitval parse_unitval( const std::string&, const std::string&, const unit_types& );
 
     /*! Allow us to assign a unitval to a double.
      *  \note    Do not use this in Hector.  It is intended for other
@@ -223,7 +223,7 @@ void unitval::set( double v, unit_types u, double err=0.0 ) {
  *  Get value. Caller has to provide assumed units, as a check.
  */
 inline
-double unitval::value( unit_types u ) const throw( h_exception ) {
+double unitval::value( unit_types u ) const {
     H_ASSERT( u==valUnits, "variable is not of this type.  Expected: " + unitsName(valUnits) +
              "; got: " + unitsName(u) );
     return( val );

--- a/src/bc_component.cpp
+++ b/src/bc_component.cpp
@@ -58,7 +58,7 @@ void BlackCarbonComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval BlackCarbonComponent::sendMessage( const std::string& message,
                                           const std::string& datum,
-                                          const message_data info ) throw ( h_exception )
+                                          const message_data info )
 {
     unitval returnval;
 
@@ -80,7 +80,7 @@ unitval BlackCarbonComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void BlackCarbonComponent::setData( const string& varName,
-                                    const message_data& data ) throw ( h_exception )
+                                    const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -99,7 +99,7 @@ void BlackCarbonComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void BlackCarbonComponent::prepareToRun() throw ( h_exception ) {
+void BlackCarbonComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -107,7 +107,7 @@ void BlackCarbonComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void BlackCarbonComponent::run( const double runToDate ) throw ( h_exception ) {
+void BlackCarbonComponent::run( const double runToDate ) {
     H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
     oldDate = runToDate;
 }
@@ -115,7 +115,7 @@ void BlackCarbonComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval BlackCarbonComponent::getData( const std::string& varName,
-                                      const double date ) throw ( h_exception ) {
+                                      const double date ) {
 
     unitval returnval;
 
@@ -130,7 +130,7 @@ unitval BlackCarbonComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void BlackCarbonComponent::reset(double time) throw(h_exception)
+void BlackCarbonComponent::reset(double time)
 {
     // Set time counter to requested date; there are no outputs to
     // reset.

--- a/src/carbon-cycle-solver.cpp
+++ b/src/carbon-cycle-solver.cpp
@@ -182,7 +182,7 @@ void CarbonCycleSolver::shutDown()
  */
 void CarbonCycleSolver::ODEEvalFunctor::operator()( const std::vector<double>& y,
                                                     std::vector<double>& dydt,
-                                                    double t ) throw ( bad_derivative_exception )
+                                                    double t )
 {
     // Note the std garuntees vetors are contigous so we can convert to array by
     // taking the address of the first value.

--- a/src/carbon-cycle-solver.cpp
+++ b/src/carbon-cycle-solver.cpp
@@ -64,7 +64,7 @@ void CarbonCycleSolver::init( Core* coreptr ) {
 // documentation is inherited
 unitval CarbonCycleSolver::sendMessage( const std::string& message,
                                        const std::string& datum,
-                                       const message_data info ) throw ( h_exception )
+                                       const message_data info )
 {
     unitval returnval;
 
@@ -86,7 +86,7 @@ unitval CarbonCycleSolver::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CarbonCycleSolver::setData( const std::string &varName,
-                                 const message_data& data ) throw ( h_exception )
+                                 const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -121,7 +121,7 @@ void CarbonCycleSolver::setData( const std::string &varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void CarbonCycleSolver::prepareToRun() throw( h_exception )
+void CarbonCycleSolver::prepareToRun()
 {
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
@@ -141,7 +141,7 @@ void CarbonCycleSolver::prepareToRun() throw( h_exception )
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval CarbonCycleSolver::getData( const std::string& varName,
-                                   const double date ) throw ( h_exception ) {
+                                   const double date ) {
 
     unitval returnval;
 
@@ -152,7 +152,7 @@ unitval CarbonCycleSolver::getData( const std::string& varName,
     return returnval;
 }
 
-void CarbonCycleSolver::reset(double time) throw(h_exception)
+void CarbonCycleSolver::reset(double time)
 {
     // Only state maintained by this component is the time counter
     t = time;
@@ -216,7 +216,7 @@ void CarbonCycleSolver::ODEEvalFunctor::operator()( const std::vector<double>& y
  *  \param[in] tmid     middle of time step
  *  \exception          will always happen; gsl solver has failed
  */
-void CarbonCycleSolver::failure( int stat, double t0, double tmid ) throw( h_exception ) {
+void CarbonCycleSolver::failure( int stat, double t0, double tmid ) {
     H_LOG( logger, Logger::SEVERE ) << "gsl_ode_evolve_apply failed at t= " <<
     t0 << "  tinit= " << t << "  tmid = " << tmid << "  last dt= " <<
     dt << "\nError code: " << stat << "\ncvals:\n";
@@ -228,7 +228,7 @@ void CarbonCycleSolver::failure( int stat, double t0, double tmid ) throw( h_exc
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void CarbonCycleSolver::run( const double tnew ) throw ( h_exception )
+void CarbonCycleSolver::run( const double tnew )
 {
     if(tnew <= t) {
         H_LOG(logger, Logger::SEVERE) << "run(): tnew= " << tnew << "   t= " << t << std::endl;
@@ -309,7 +309,7 @@ void CarbonCycleSolver::run( const double tnew ) throw ( h_exception )
  *  carbon pools, at the end of the preindustrial period before the main run.
  *  To reach this point, run the carbon model until all dc/dt are ~0.
  */
-bool CarbonCycleSolver::run_spinup( const int step ) throw( h_exception )
+bool CarbonCycleSolver::run_spinup( const int step )
 {
 
     if( !in_spinup ) {  // first time

--- a/src/ch4_component.cpp
+++ b/src/ch4_component.cpp
@@ -67,7 +67,7 @@ void CH4Component::init( Core* coreptr ) {
 // documentation is inherited
 unitval CH4Component::sendMessage( const std::string& message,
                                   const std::string& datum,
-                                  const message_data info ) throw ( h_exception ) {
+                                  const message_data info ) {
     unitval returnval;
 
     if( message==M_GETDATA ) {          //! Caller is requesting data
@@ -89,7 +89,7 @@ unitval CH4Component::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CH4Component::setData( const string& varName,
-                            const message_data& data ) throw ( h_exception ) {
+                            const message_data& data ) {
     try {
          if( varName ==  D_PREINDUSTRIAL_CH4  ) {
             H_ASSERT( data.date == Core::undefinedIndex() , "date not allowed" );
@@ -124,7 +124,7 @@ void CH4Component::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void CH4Component::prepareToRun() throw ( h_exception ) {
+void CH4Component::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -137,7 +137,7 @@ void CH4Component::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void CH4Component::run( const double runToDate ) throw ( h_exception ) {
+void CH4Component::run( const double runToDate ) {
 	H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
 
     if ( CH4_constrain.size() && CH4_constrain.exists( runToDate ) ) {
@@ -177,7 +177,7 @@ void CH4Component::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval CH4Component::getData( const std::string& varName,
-                              const double date ) throw ( h_exception ) {
+                              const double date ) {
 
     unitval returnval;
 
@@ -206,7 +206,7 @@ unitval CH4Component::getData( const std::string& varName,
     return returnval;
 }
 
-void CH4Component::reset(double time) throw(h_exception) {
+void CH4Component::reset(double time) {
     // reset the internal time counter and truncate concentration time
     // series
     oldDate = time;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -203,7 +203,7 @@ void Core::init() {
  *  \exception h_exception If either the componentName or varName was not recognized.
  */
 void Core::setData( const string& componentName, const string& varName,
-                    const message_data& data ) throw ( h_exception )
+                    const message_data& data )
 {
     if( componentName == getComponentName() ) {
         try {
@@ -282,7 +282,7 @@ void Core::addVisitor( AVisitor* visitor ) {
  *
  *  \exception h_exception An error which may occur at any stage of the process.
  */
-void Core::prepareToRun(void) throw (h_exception)
+void Core::prepareToRun(void)
 {
 
     /* Most of this stuff only needs to be done once, even if we reset the
@@ -417,7 +417,7 @@ bool Core::run_spinup()
  *  \exception h_exception An error which may occur at any stage of the process.
  */
 
-void Core::run(double runtodate) throw ( h_exception ) {
+void Core::run(double runtodate) {
     if(runtodate < 0.0) {
         // run to the configured default enddate.  This is mainly for
         // backward compatibility.  The input run-to date will always
@@ -510,7 +510,7 @@ void Core::shutDown()
  *  \param componentName The name of the component to retrieve.
  *  \exception h_exception If the componentName was not recognized.
  */
-IModelComponent* Core::getComponentByName( const string& componentName ) const throw ( h_exception )
+IModelComponent* Core::getComponentByName( const string& componentName ) const
 {
     CNameComponentIterator it = modelComponents.find( componentName );
 
@@ -526,7 +526,7 @@ IModelComponent* Core::getComponentByName( const string& componentName ) const t
  *  \param componentName The capability of the component to retrieve.
  *  \exception h_exception If the capabilityName was not recognized.
  */
-IModelComponent* Core::getComponentByCapability( const string& capabilityName ) const throw ( h_exception )
+IModelComponent* Core::getComponentByCapability( const string& capabilityName ) const
 {
     H_ASSERT( isInited, "getComponentByCapability not available until core is initialized")
 
@@ -553,7 +553,7 @@ IModelComponent* Core::getComponentByCapability( const string& capabilityName ) 
  * \note By "capability" we mean any piece of data that the component wants to expose to the model core or other components; this can be an input, an output, or an internal variable.
  */
 void Core::registerCapability(const string& capabilityName, const string& componentName, bool warndupe
-                              )  throw ( h_exception ){
+                              ) {
     H_ASSERT( !isInited, "registerCapability not available after core is initialized")
 
     // check whether the capability already exists
@@ -621,7 +621,7 @@ void Core::registerDependency( const string& capabilityName, const string& compo
  *  \exception h_exception If the componentName was not recognized.
  */
 unitval Core::sendMessage( const std::string& message,
-                          const std::string& datum ) throw ( h_exception )
+                          const std::string& datum )
 {
     return sendMessage( message, datum, message_data() );
 }
@@ -635,7 +635,7 @@ unitval Core::sendMessage( const std::string& message,
  */
 unitval Core::sendMessage( const std::string& message,
                           const std::string& datum,
-                          const message_data& info ) throw ( h_exception )
+                          const message_data& info )
 {
 
     std::vector<std::string> datum_split;
@@ -696,7 +696,7 @@ unitval Core::sendMessage( const std::string& message,
  *                         may not be added.
  *  \note The core assumes ownership of memory associated with all components.
  */
-void Core::addModelComponent( IModelComponent* modelComponent ) throw ( h_exception ) {
+void Core::addModelComponent( IModelComponent* modelComponent ) {
     H_ASSERT( !isInited, "Model components can only be added before initialization." );
 
     modelComponents[ modelComponent->getComponentName() ] = modelComponent;

--- a/src/csv_table_reader.cpp
+++ b/src/csv_table_reader.cpp
@@ -40,7 +40,7 @@ using namespace std;
  *  \param fileName The name of a csv file to read from.
  *  \exception h_exception If there were errors when opening the file.
  */
-CSVTableReader::CSVTableReader( const string& fileName ) throw ( h_exception )
+CSVTableReader::CSVTableReader( const string& fileName )
 :fileName( fileName )
 {
     // allow exceptions from bad io operations
@@ -113,7 +113,7 @@ string CSVTableReader::csv_getline() {
  */
 
 void CSVTableReader::process( Core* core, const string& componentName,
-                             const string& varName ) throw ( h_exception )
+                             const string& varName )
 {
     using namespace boost;
     try {

--- a/src/dependency_finder.cpp
+++ b/src/dependency_finder.cpp
@@ -82,7 +82,7 @@ bool DependencyFinder::addDependency( const string& aObjectName,
  * \pre All relevant objects must have called addDependency() to add their dependencies to the matrix.
  * \sa getOrdering
  */
-void DependencyFinder::createOrdering() throw ( h_exception ) {
+void DependencyFinder::createOrdering() {
     // If there is an existing stored ordering, clear it.
     mOrdering.clear();
 

--- a/src/dummy_model_component.cpp
+++ b/src/dummy_model_component.cpp
@@ -74,7 +74,7 @@ void DummyModelComponent::init( Core* core ) {
 // documentation is inherited
 unitval DummyModelComponent::sendMessage( const std::string& message,
                                          const std::string& datum,
-                                         const message_data info ) throw ( h_exception )
+                                         const message_data info )
 {
     unitval returnval;
 
@@ -96,7 +96,7 @@ unitval DummyModelComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void DummyModelComponent::setData( const string& varName,
-                                   const message_data& data ) throw ( h_exception )
+                                   const message_data& data )
 {
     try {
         if( varName == H_STRINGIFY_VAR( slope ) ) {
@@ -118,7 +118,7 @@ void DummyModelComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void DummyModelComponent::prepareToRun() throw ( h_exception ) {
+void DummyModelComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
@@ -131,7 +131,7 @@ void DummyModelComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void DummyModelComponent::run( const double runToDate ) throw ( h_exception ) {
+void DummyModelComponent::run( const double runToDate ) {
     // for some reason we need to calculate at a time-step of .1
     const double timeStep = 0.1;
     // make sure we can take at least 1 time-step.
@@ -146,7 +146,7 @@ void DummyModelComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval DummyModelComponent::getData( const std::string& varName,
-                                     const double date ) throw ( h_exception ) {
+                                     const double date ) {
 
     unitval returnval;
 
@@ -160,7 +160,7 @@ unitval DummyModelComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void DummyModelComponent::reset(double time) throw(h_exception)
+void DummyModelComponent::reset(double time)
 {
     // This is a no-op for this component
     H_LOG(logger, Logger::NOTICE)

--- a/src/forcing_component.cpp
+++ b/src/forcing_component.cpp
@@ -200,7 +200,7 @@ void ForcingComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval ForcingComponent::sendMessage( const std::string& message,
                                       const std::string& datum,
-                                      const message_data info ) throw ( h_exception )
+                                      const message_data info )
 {
     unitval returnval;
 
@@ -222,7 +222,7 @@ unitval ForcingComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void ForcingComponent::setData( const string& varName,
-                                const message_data& data ) throw ( h_exception )
+                                const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -245,7 +245,7 @@ void ForcingComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void ForcingComponent::prepareToRun() throw ( h_exception ) {
+void ForcingComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
@@ -265,7 +265,7 @@ void ForcingComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void ForcingComponent::run( const double runToDate ) throw ( h_exception ) {
+void ForcingComponent::run( const double runToDate ) {
 
     // Calculate instantaneous radiative forcing for any & all agents
     // As each is computed, push it into 'forcings' map for Ftot calculation.
@@ -444,7 +444,7 @@ void ForcingComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval ForcingComponent::getData( const std::string& varName,
-                                  const double date ) throw ( h_exception ) {
+                                  const double date ) {
 
 
     unitval returnval;
@@ -513,7 +513,7 @@ unitval ForcingComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void ForcingComponent::reset(double time) throw(h_exception)
+void ForcingComponent::reset(double time)
 {
     // Set the current year to the reset year, and drop outputs after the reset year.
     currentYear = time;

--- a/src/h_reader.cpp
+++ b/src/h_reader.cpp
@@ -35,7 +35,7 @@ h_reader::h_reader( std::string fname, readertype_t style, bool doparse ) {
  *
  *  Backend is currently an INIReader.
  */
-void h_reader::parse() throw( h_exception ) {
+void h_reader::parse() {
     if(reader)
         delete reader;
 

--- a/src/halocarbon_component.cpp
+++ b/src/halocarbon_component.cpp
@@ -73,7 +73,7 @@ void HalocarbonComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval HalocarbonComponent::sendMessage( const std::string& message,
                                          const std::string& datum,
-                                         const message_data info ) throw ( h_exception )
+                                         const message_data info )
 {
     unitval returnval;
 
@@ -95,7 +95,7 @@ unitval HalocarbonComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void HalocarbonComponent::setData( const string& varName,
-                                   const message_data& data ) throw ( h_exception )
+                                   const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -133,7 +133,7 @@ void HalocarbonComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void HalocarbonComponent::prepareToRun() throw ( h_exception ) {
+void HalocarbonComponent::prepareToRun() {
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
 
@@ -150,7 +150,7 @@ void HalocarbonComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void HalocarbonComponent::run( const double runToDate ) throw ( h_exception ) {
+void HalocarbonComponent::run( const double runToDate ) {
 	H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
     #define AtmosphereDryAirConstant 1.8
 
@@ -189,7 +189,7 @@ void HalocarbonComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval HalocarbonComponent::getData( const std::string& varName,
-                                     const double date ) throw ( h_exception ) {
+                                     const double date ) {
 
     unitval returnval;
     double getdate = date;      // will be used for any variable where a date is allowed.
@@ -237,7 +237,7 @@ unitval HalocarbonComponent::getData( const std::string& varName,
 }
 
 
-void HalocarbonComponent::reset(double time) throw(h_exception)
+void HalocarbonComponent::reset(double time)
 {
     // reset time counter and truncate outputs
     oldDate = time;

--- a/src/ini_to_core_reader.cpp
+++ b/src/ini_to_core_reader.cpp
@@ -61,7 +61,7 @@ INIToCoreReader::~INIToCoreReader() {
  *                         or there was a problem in the Core trying to set the
  *                         data.
  */
-void INIToCoreReader::parse( const string& filename ) throw ( h_exception ) {
+void INIToCoreReader::parse( const string& filename ) {
     iniFilePath = filename;
     int errorCode = ini_parse( filename.c_str(), valueHandler, this );
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -151,7 +151,7 @@ Logger::~Logger() {
  *
  */
 void Logger::open( const string& logName, bool echoToScreen,
-                   bool echoToFile, LogLevel minLogLevel ) throw ( h_exception ) {
+                   bool echoToFile, LogLevel minLogLevel ) {
     H_ASSERT( !isInitialized, "This log has already been initialized." );
 
     this->minLogLevel = minLogLevel;
@@ -199,7 +199,7 @@ bool Logger::shouldWrite( const LogLevel writeLevel ) const {
  *  \exception h_exception If this logger has not been initialized.
  */
 ostream& Logger::write( const LogLevel writeLevel,
-                       const string& functionInfo ) throw ( h_exception )
+                       const string& functionInfo )
 {
     H_ASSERT( isInitialized, "can't write to logger until initialized" );
 

--- a/src/n2o_component.cpp
+++ b/src/n2o_component.cpp
@@ -74,7 +74,7 @@ void N2OComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval N2OComponent::sendMessage( const std::string& message,
                                   const std::string& datum,
-                                  const message_data info ) throw ( h_exception )
+                                  const message_data info )
 {
     unitval returnval;
 
@@ -96,7 +96,7 @@ unitval N2OComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void N2OComponent::setData( const string& varName,
-                            const message_data& data ) throw ( h_exception )
+                            const message_data& data )
 {
     try {
         if( varName == D_PREINDUSTRIAL_N2O ) {
@@ -131,7 +131,7 @@ void N2OComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void N2OComponent::prepareToRun() throw ( h_exception ) {
+void N2OComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -145,7 +145,7 @@ void N2OComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void N2OComponent::run( const double runToDate ) throw ( h_exception ) {
+void N2OComponent::run( const double runToDate ) {
 
 	H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
 
@@ -180,7 +180,7 @@ void N2OComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval N2OComponent::getData( const std::string& varName,
-                              const double date ) throw ( h_exception ) {
+                              const double date ) {
 
     unitval returnval;
 
@@ -212,7 +212,7 @@ unitval N2OComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void N2OComponent::reset(double time) throw(h_exception)
+void N2OComponent::reset(double time)
 {
     // reset time counter, and truncate output time series
     oldDate = time;

--- a/src/o3_component.cpp
+++ b/src/o3_component.cpp
@@ -70,7 +70,7 @@ void OzoneComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval OzoneComponent::sendMessage( const std::string& message,
                                     const std::string& datum,
-                                    const message_data info ) throw ( h_exception )
+                                    const message_data info )
 {
     unitval returnval;
 
@@ -92,7 +92,7 @@ unitval OzoneComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OzoneComponent::setData( const string& varName,
-                              const message_data& data ) throw ( h_exception )
+                              const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -120,7 +120,7 @@ void OzoneComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OzoneComponent::prepareToRun() throw ( h_exception ) {
+void OzoneComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -129,7 +129,7 @@ void OzoneComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OzoneComponent::run( const double runToDate ) throw ( h_exception ) {
+void OzoneComponent::run( const double runToDate ) {
 
 	// Calculate O3 based on NOX, CO, NMVOC, CH4.
     // Modified from Tanaka et al 2007
@@ -150,7 +150,7 @@ void OzoneComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval OzoneComponent::getData( const std::string& varName,
-                                 const double date ) throw ( h_exception ) {
+                                 const double date ) {
 
     unitval returnval;
 
@@ -165,7 +165,7 @@ unitval OzoneComponent::getData( const std::string& varName,
 }
 
 
-void OzoneComponent::reset(double time) throw(h_exception)
+void OzoneComponent::reset(double time)
 {
     O3.truncate(time);
     oldDate = time;

--- a/src/oc_component.cpp
+++ b/src/oc_component.cpp
@@ -59,7 +59,7 @@ void OrganicCarbonComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval OrganicCarbonComponent::sendMessage( const std::string& message,
                                             const std::string& datum,
-                                            const message_data info ) throw ( h_exception )
+                                            const message_data info )
 {
     unitval returnval;
 
@@ -82,7 +82,7 @@ unitval OrganicCarbonComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OrganicCarbonComponent::setData( const string& varName,
-                                      const message_data& data ) throw ( h_exception )
+                                      const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -101,7 +101,7 @@ void OrganicCarbonComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OrganicCarbonComponent::prepareToRun() throw ( h_exception ) {
+void OrganicCarbonComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -109,7 +109,7 @@ void OrganicCarbonComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OrganicCarbonComponent::run( const double runToDate ) throw ( h_exception ) {
+void OrganicCarbonComponent::run( const double runToDate ) {
 	H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
     oldDate = runToDate;
 }
@@ -117,7 +117,7 @@ void OrganicCarbonComponent::run( const double runToDate ) throw ( h_exception )
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval OrganicCarbonComponent::getData( const std::string& varName,
-                                        const double date ) throw ( h_exception ) {
+                                        const double date ) {
 
     unitval returnval;
 
@@ -132,7 +132,7 @@ unitval OrganicCarbonComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void OrganicCarbonComponent::reset(double time) throw(h_exception)
+void OrganicCarbonComponent::reset(double time)
 {
     oldDate = time;
     H_LOG(logger, Logger::NOTICE)

--- a/src/ocean_component.cpp
+++ b/src/ocean_component.cpp
@@ -87,7 +87,7 @@ void OceanComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval OceanComponent::sendMessage( const std::string& message,
                                     const std::string& datum,
-                                    const message_data info ) throw ( h_exception )
+                                    const message_data info )
 {
     unitval returnval;
 
@@ -116,7 +116,7 @@ unitval OceanComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OceanComponent::setData( const string& varName,
-                              const message_data& data ) throw ( h_exception )
+                              const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -162,7 +162,7 @@ void OceanComponent::setData( const string& varName,
 //------------------------------------------------------------------------------
 // documentation is inherited
 // TO DO: should we put these in the ini file instead?
-void OceanComponent::prepareToRun() throw ( h_exception ) {
+void OceanComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
@@ -278,7 +278,7 @@ unitval OceanComponent::annual_totalcflux( const double date, const unitval& Ca,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OceanComponent::run( const double runToDate ) throw ( h_exception ) {
+void OceanComponent::run( const double runToDate ) {
 
     Ca = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2 );
     Tgav = core->sendMessage( M_GETDATA, D_GLOBAL_TEMP );
@@ -323,7 +323,7 @@ void OceanComponent::run( const double runToDate ) throw ( h_exception ) {
 }
     //------------------------------------------------------------------------------
 // documentation is inherited
-bool OceanComponent::run_spinup( const int step ) throw ( h_exception ) {
+bool OceanComponent::run_spinup( const int step ) {
     run( step );
     return true;        // solver will be the one signalling
 }
@@ -331,7 +331,7 @@ bool OceanComponent::run_spinup( const int step ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval OceanComponent::getData( const std::string& varName,
-                                const double date ) throw ( h_exception ) {
+                                const double date ) {
 
     unitval returnval;
 
@@ -551,7 +551,7 @@ void OceanComponent::stashCValues( double t, const double c[] ) {
    }
 
 
-void OceanComponent::reset(double time) throw(h_exception)
+void OceanComponent::reset(double time)
 {
 
     // Reset state variables to their values at the reset time

--- a/src/oh_component.cpp
+++ b/src/oh_component.cpp
@@ -69,7 +69,7 @@ void OHComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval OHComponent::sendMessage( const std::string& message,
                                   const std::string& datum,
-                                  const message_data info ) throw ( h_exception )
+                                  const message_data info )
 {
     unitval returnval;
 
@@ -89,7 +89,7 @@ unitval OHComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OHComponent::setData( const string& varName,
-                            const message_data& data ) throw ( h_exception )
+                            const message_data& data )
 {
     try {
          if( varName == D_EMISSIONS_NOX ) {
@@ -127,7 +127,7 @@ void OHComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OHComponent::prepareToRun() throw ( h_exception ) {
+void OHComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -138,7 +138,7 @@ void OHComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OHComponent::run( const double runToDate ) throw ( h_exception )
+void OHComponent::run( const double runToDate )
 {
     H_LOG(logger, Logger::DEBUG) << "olddate:  " << oldDate << " runToDate: " << runToDate << std::endl;
     H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
@@ -171,7 +171,7 @@ void OHComponent::run( const double runToDate ) throw ( h_exception )
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval OHComponent::getData( const std::string& varName,
-                              const double date ) throw ( h_exception ) {
+                              const double date ) {
 
     unitval returnval;
 
@@ -194,7 +194,7 @@ unitval OHComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void OHComponent::reset(double time) throw(h_exception)
+void OHComponent::reset(double time)
 {
     oldDate = time;
     H_LOG(logger, Logger::NOTICE)

--- a/src/onelineocean_component.cpp
+++ b/src/onelineocean_component.cpp
@@ -55,7 +55,7 @@ void OneLineOceanComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval OneLineOceanComponent::sendMessage( const std::string& message,
                                            const std::string& datum,
-                                           const message_data info ) throw ( h_exception )
+                                           const message_data info )
 {
     unitval returnval;
 
@@ -78,7 +78,7 @@ unitval OneLineOceanComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void OneLineOceanComponent::setData( const string& varName,
-                                     const message_data& data ) throw ( h_exception )
+                                     const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -97,7 +97,7 @@ void OneLineOceanComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OneLineOceanComponent::prepareToRun() throw ( h_exception ) {
+void OneLineOceanComponent::prepareToRun() {
 
     oldDate = core->getStartDate();
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
@@ -105,7 +105,7 @@ void OneLineOceanComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void OneLineOceanComponent::run( const double runToDate ) throw ( h_exception ) {
+void OneLineOceanComponent::run( const double runToDate ) {
 
     double atmos_c = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_C ).value( U_PGC );
     unitval atmos_co2 = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2 );
@@ -128,7 +128,7 @@ void OneLineOceanComponent::run( const double runToDate ) throw ( h_exception ) 
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval OneLineOceanComponent::getData( const std::string& varName,
-                                       const double date ) throw ( h_exception ) {
+                                       const double date ) {
 
     unitval returnval;
 
@@ -148,7 +148,7 @@ unitval OneLineOceanComponent::getData( const std::string& varName,
 }
 
 
-void OneLineOceanComponent::reset(double time) throw(h_exception)
+void OneLineOceanComponent::reset(double time)
 {
     oldDate = time;
     H_LOG(logger, Logger::NOTICE)

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -98,7 +98,7 @@ void SimpleNbox::init( Core* coreptr ) {
 // documentation is inherited
 unitval SimpleNbox::sendMessage( const std::string& message,
                                 const std::string& datum,
-                                const message_data info ) throw ( h_exception )
+                                const message_data info )
 {
     unitval returnval;
 
@@ -121,7 +121,7 @@ unitval SimpleNbox::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void SimpleNbox::setData( const std::string &varName,
-                          const message_data& data ) throw( h_exception )
+                          const message_data& data )
 {
     // Does the varName contain our parse character? If so, split it
     std::vector<std::string> splitvec;
@@ -297,9 +297,8 @@ void SimpleNbox::setData( const std::string &varName,
  *  For example, the main carbon pools (except earth) should always be positive;
  *  partitioning coefficients should not exceed 1; etc.
  */
-void SimpleNbox::sanitychecks() throw( h_exception )
+void SimpleNbox::sanitychecks()
 {
-
     // Make a few sanity checks here, and then return.
     H_ASSERT( atmos_c.value( U_PGC ) > 0.0, "atmos_c pool <=0" );
 
@@ -374,7 +373,7 @@ void SimpleNbox::log_pools( const double t )
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void SimpleNbox::prepareToRun() throw( h_exception )
+void SimpleNbox::prepareToRun()
 {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
@@ -441,7 +440,7 @@ void SimpleNbox::prepareToRun() throw( h_exception )
  *  This run method doesn't do much, because it's the carbon-cycle-solver
  *  run that does all the work.
  */
-void SimpleNbox::run( const double runToDate ) throw ( h_exception )
+void SimpleNbox::run( const double runToDate )
 {
     in_spinup = core->inSpinup();
     sanitychecks();
@@ -456,7 +455,7 @@ void SimpleNbox::run( const double runToDate ) throw ( h_exception )
  *  This run_spinup method doesn't do much, because it's the carbon-cycle-solver
  *  run that does all the work.
  */
-bool SimpleNbox::run_spinup( const int step ) throw ( h_exception )
+bool SimpleNbox::run_spinup( const int step )
 {
     sanitychecks();
     in_spinup = true;
@@ -466,7 +465,7 @@ bool SimpleNbox::run_spinup( const int step ) throw ( h_exception )
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval SimpleNbox::getData(const std::string& varName,
-                            const double date) throw ( h_exception )
+                            const double date)
 {
     unitval returnval;
 
@@ -620,7 +619,7 @@ unitval SimpleNbox::getData(const std::string& varName,
     return returnval;
 }
 
-void SimpleNbox::reset(double time) throw(h_exception)
+void SimpleNbox::reset(double time)
 {
     // Reset all state variables to their values at the reset time
     earth_c = earth_c_ts.get(time);

--- a/src/slr_component.cpp
+++ b/src/slr_component.cpp
@@ -68,7 +68,7 @@ void slrComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval slrComponent::sendMessage( const std::string& message,
                                   const std::string& datum,
-                                  const message_data info ) throw ( h_exception )
+                                  const message_data info )
 {
     unitval returnval;
 
@@ -91,7 +91,7 @@ unitval slrComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void slrComponent::setData( const string& varName,
-                            const message_data& data ) throw ( h_exception )
+                            const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -101,7 +101,7 @@ void slrComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void slrComponent::prepareToRun() throw ( h_exception ) {
+void slrComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -184,7 +184,7 @@ void slrComponent::compute_slr( const double date ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void slrComponent::run( const double runToDate ) throw ( h_exception ) {
+void slrComponent::run( const double runToDate ) {
 
     H_LOG( logger, Logger::DEBUG ) << "SLR run " << runToDate << std::endl;
 
@@ -215,7 +215,7 @@ void slrComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval slrComponent::getData( const std::string& varName,
-                              const double date ) throw ( h_exception ) {
+                              const double date ) {
 
     unitval returnval;
 
@@ -236,7 +236,7 @@ unitval slrComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void slrComponent::reset(double time) throw(h_exception)
+void slrComponent::reset(double time)
 {
     oldDate = time;
     sl_rc.truncate(time);

--- a/src/so2_component.cpp
+++ b/src/so2_component.cpp
@@ -64,7 +64,7 @@ void SulfurComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval SulfurComponent::sendMessage( const std::string& message,
                                      const std::string& datum,
-                                     const message_data info ) throw ( h_exception )
+                                     const message_data info )
 {
     unitval returnval;
 
@@ -87,7 +87,7 @@ unitval SulfurComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void SulfurComponent::setData( const string& varName,
-                               const message_data& data ) throw ( h_exception )
+                               const message_data& data )
 {
     H_LOG( logger, Logger::DEBUG ) << "Setting " << varName << "[" << data.date << "]=" << data.value_str << std::endl;
 
@@ -119,7 +119,7 @@ void SulfurComponent::setData( const string& varName,
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void SulfurComponent::prepareToRun() throw ( h_exception ) {
+void SulfurComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
     oldDate = core->getStartDate();
@@ -127,7 +127,7 @@ void SulfurComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void SulfurComponent::run( const double runToDate ) throw ( h_exception ) {
+void SulfurComponent::run( const double runToDate ) {
     H_ASSERT( !core->inSpinup() && runToDate-oldDate == 1, "timestep must equal 1" );
     oldDate = runToDate;
 }
@@ -135,7 +135,7 @@ void SulfurComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval SulfurComponent::getData( const std::string& varName,
-                                 const double date ) throw ( h_exception ) {
+                                 const double date ) {
 
     unitval returnval;
 
@@ -163,7 +163,7 @@ unitval SulfurComponent::getData( const std::string& varName,
     return returnval;
 }
 
-void SulfurComponent::reset(double time) throw(h_exception)
+void SulfurComponent::reset(double time)
 {
     // This component doesn't calculate anything, so all we have to do
     // is reset the time counter.

--- a/src/temperature_component.cpp
+++ b/src/temperature_component.cpp
@@ -133,7 +133,7 @@ void TemperatureComponent::init( Core* coreptr ) {
 // documentation is inherited
 unitval TemperatureComponent::sendMessage( const std::string& message,
                                     const std::string& datum,
-                                    const message_data info ) throw ( h_exception )
+                                    const message_data info )
 {
     unitval returnval;
 
@@ -151,7 +151,7 @@ unitval TemperatureComponent::sendMessage( const std::string& message,
 //------------------------------------------------------------------------------
 // documentation is inherited
 void TemperatureComponent::setData( const string& varName,
-                              const message_data& data ) throw ( h_exception )
+                              const message_data& data )
 {
     using namespace boost;
 
@@ -188,7 +188,7 @@ void TemperatureComponent::setData( const string& varName,
 //------------------------------------------------------------------------------
 // documentation is inherited
 // TO DO: should we put these in the ini file instead?
-void TemperatureComponent::prepareToRun() throw ( h_exception ) {
+void TemperatureComponent::prepareToRun() {
 
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
@@ -316,7 +316,7 @@ void TemperatureComponent::prepareToRun() throw ( h_exception ) {
 
 //------------------------------------------------------------------------------
 // documentation is inherited
-void TemperatureComponent::run( const double runToDate ) throw ( h_exception ) {
+void TemperatureComponent::run( const double runToDate ) {
     H_LOG( logger, Logger::DEBUG ) << "temperature run " << runToDate << std::endl;
 
     // Commented section below is for case of user-specified temperature record.
@@ -441,7 +441,7 @@ void TemperatureComponent::run( const double runToDate ) throw ( h_exception ) {
 //------------------------------------------------------------------------------
 // documentation is inherited
 unitval TemperatureComponent::getData( const std::string& varName,
-                                const double date ) throw ( h_exception ) {
+                                const double date ) {
 
     unitval returnval;
 
@@ -507,7 +507,7 @@ unitval TemperatureComponent::getData( const std::string& varName,
 }
 
 
-void TemperatureComponent::reset(double time) throw(h_exception)
+void TemperatureComponent::reset(double time)
 {
     // We take a slightly different approach in this component's reset method than we have in other components.  The
     // temperature component doesn't have its own time counter, and it stores its history in a collection of double

--- a/src/unitval.cpp
+++ b/src/unitval.cpp
@@ -126,7 +126,7 @@ string unitval::unitsName( const unit_types u ) {
  *  Uses names consistent with unitsName to translate between strings and
  *  unit_types.
  */
-unit_types unitval::parseUnitsName( const string& unitsStr ) throw( h_exception ) {
+unit_types unitval::parseUnitsName( const string& unitsStr ) {
     // Iterate over all the enumerated units and check if its unitsName() matches
     // the given units string.
     /*!
@@ -157,7 +157,7 @@ unit_types unitval::parseUnitsName( const string& unitsStr ) throw( h_exception 
  *      - The units string (if set) does not match the expected units.
  */
 unitval unitval::parse_unitval( const string& unitvalStr,
-                               const unit_types& expectedUnits ) throw( h_exception )
+                               const unit_types& expectedUnits )
 {
     // we are assuming that should units exist they will be in the format of:
     // [value],[units]
@@ -188,7 +188,7 @@ unitval unitval::parse_unitval( const string& unitvalStr,
  *      - The units string (if set) does not match the expected units.
  */
 unitval unitval::parse_unitval( const string& valueStr, const string& unitsStr,
-                               const unit_types& expectedUnits ) throw( h_exception )
+                               const unit_types& expectedUnits )
 {
     // Double check if a user really provided a single unitval string in which
     // case it should be re-parsed before converting.
@@ -226,7 +226,7 @@ unitval unitval::parse_unitval( const string& valueStr, const string& unitsStr,
  *  \exception h_exception An exception may be raised for the following reasons:
  *      - The originally set units do not match the expected units.
  */
-void unitval::expecting_unit( const unit_types& expectedUnits ) throw( h_exception ) {
+void unitval::expecting_unit( const unit_types& expectedUnits ) {
     if (valUnits == U_UNDEFINED) {
         valUnits = expectedUnits;
     } else {


### PR DESCRIPTION
Remove all throw() specifications on functions. The only exceptions is `class h_exception : public std::exception` which apparently has to define `const char* what() const throw()`.

More information: https://stackoverflow.com/questions/13841559/deprecated-throw-list-in-c11

Closes #257
