### PR TITLE
Clarify forcing names 

### DIFF
--- a/inst/include/component_data.hpp
+++ b/inst/include/component_data.hpp
@@ -216,8 +216,6 @@
 #define D_EMISSIONS_NOX           "NOX_emissions"
 #define D_EMISSIONS_CO            "CO_emissions"
 #define D_EMISSIONS_NMVOC         "NMVOC_emissions"
-//Do not redefine Ma though it is used for o3 component
-//#define D_EMISSIONS_O3 "O3_concentration"
 
 // oc component
 #define D_EMISSIONS_OC          "OC_emissions"

--- a/src/forcing_component.cpp
+++ b/src/forcing_component.cpp
@@ -311,16 +311,16 @@ void ForcingComponent::run( const double runToDate ) {
 
             // ---------- Stratospheric H2O from CH4 oxidation ----------
             // From Tanaka et al, 2007, but using Joos et al., 2001 value of 0.05
-            const double fh2o = 0.05 * ( 0.036 * ( sqrt( Ma ) - sqrt( M0 ) ) );
-            forcings[D_RF_H2O_STRAT].set( fh2o, U_W_M2 );
+            const double fh2o_strat = 0.05 * ( 0.036 * ( sqrt( Ma ) - sqrt( M0 ) ) );
+            forcings[D_RF_H2O_STRAT].set( fh2o_strat, U_W_M2 );
         }
 
         // ---------- Troposheric Ozone ----------
         if( core->checkCapability( D_ATMOSPHERIC_O3 ) ) {
             //from Tanaka et al, 2007
             const double ozone = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_O3, message_data( runToDate ) ).value( U_DU_O3 );
-            const double fo3 = 0.042 * ozone;
-            forcings[D_RF_O3_TROP].set( fo3, U_W_M2 );
+            const double fo3_trop = 0.042 * ozone;
+            forcings[D_RF_O3_TROP].set( fo3_trop, U_W_M2 );
         }
 
         // ---------- Halocarbons ----------


### PR DESCRIPTION
Closes #378

Rename H2O and O3  per @ssmithClimate  suggestion:

>(Since H2O changes in the troposphere is a feedback and, therefore, included in the climate sensitivity. And stratospheric and tropospheric O3 forcings are generally treated separately as they have different drivers and time paths.)

It looks like someone already started working on this the output returns FH2O_strat and FO3_trop , unless @ssmithClimate were you thinking that the o3 component needs to be entirely renamed? 
