### PR TITLE
Schedule CI runs once a month

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -5,6 +5,12 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+   # * is a special character in YAML so you have to quote this string, it is set up to run at 6am 
+   # on the first day of the month, this is helpful for periods of time when PRs are not being merged.
+    - cron:  '0 6 1 * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 name: test-coverage
 

--- a/.github/workflows/command-line.yaml
+++ b/.github/workflows/command-line.yaml
@@ -11,6 +11,10 @@ on:
       - github_actions
   pull_request:
     branches: master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Launch run at 6am the 1st of every month.	
+    - cron:  '0 6 1 * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,9 @@ on:
       - main
       - master
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 name: lint
 
 jobs:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,6 +3,13 @@ on:
     branches:
       - main
       - master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Launch run at 6am the 1st of every month.
+    - cron:  '0 6 1 * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 name: pkgdown
 

--- a/.github/workflows/rcmd.yml
+++ b/.github/workflows/rcmd.yml
@@ -1,4 +1,19 @@
-on: [push, pull_request]
+# Controls when the action will run.
+on:
+  push:
+    branches:
+      - master
+      - github_actions
+  pull_request:
+    branches: master
+
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Launch run at 6am the 1st of every month.
+    - cron:  '0 6 1 * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 name: R-CMD
 


### PR DESCRIPTION
While working through a Hector UI issue with @stephpenn1 it was clear that unless we are actively merging branches into the master branch that the CI won't run and catch errors when dependencies change (something is currently up with the remotes package which was causing the errors).

This PR adds the ability to launch a CI test with the press of a button on the github page without opening a PR and launches the Hector github actions suite once on the 1st day of the month. 🤷‍♀️ 