### PR TITLE
R hector read in external ini files

### DIFF
--- a/R/hector.R
+++ b/R/hector.R
@@ -84,7 +84,7 @@ runscenario <- function(infile) {
 #' @export
 newcore <- function(inifile, loglevel = 0, suppresslogging = TRUE,
                     name = "unnamed hector core") {
-  hcore <- newcore_impl(inifile, loglevel, suppresslogging, name)
+  hcore <- newcore_impl(normalizePath(inifile), loglevel, suppresslogging, name)
   class(hcore) <- c("hcore", class(hcore))
   reg.finalizer(hcore, hector::shutdown)
   hcore

--- a/vignettes/intro-to-hector.Rmd
+++ b/vignettes/intro-to-hector.Rmd
@@ -43,7 +43,7 @@ ini_file <- system.file("input/hector_rcp45.ini", package = "hector")
 ```
 
 
-Alternatively, users may provide a path to an ini file external to the Hector package on their local machine. This ini file must comply with the Hector  [ini requireiments](https://github.com/JGCRI/hector/wiki/InputFiles). 
+Alternatively, users may provide a path to an ini file external to the Hector package on their local machine. This ini file must comply with the Hector  [ini requirements](https://github.com/JGCRI/hector/wiki/InputFiles). 
 
 ```{r}
 external_ini_file <- "/path/to/ini/on/local/machine/my_ini.ini"

--- a/vignettes/intro-to-hector.Rmd
+++ b/vignettes/intro-to-hector.Rmd
@@ -42,6 +42,14 @@ Below, we get the path of the input file corresponding to the scenario RCP 4.5.
 ini_file <- system.file("input/hector_rcp45.ini", package = "hector") 
 ```
 
+
+Alternatively, users may provide a path to an ini file external to the Hector package on their local machine. This ini file must comply with the Hector  [ini requireiments](https://github.com/JGCRI/hector/wiki/InputFiles). 
+
+```{r}
+external_ini_file <- "/path/to/ini/on/local/machine/my_ini.ini"
+```
+
+
 Next, we initialize a Hector instance, or "core", using this configuration.
 This core is a self-contained object that contains information about all of Hector's inputs and outputs.
 The core is initialized via the `newcore` function:


### PR DESCRIPTION
Ensure that a normalized path is being passed into the Hector core so that the R wrapper can read in ini files defined externally to the R package. 

This is a **MINOR** change that adds functionality and continues to be backwards compatible. 

**Checklist**
- [x] [Roxygen](https://roxygen2.r-lib.org/) where applicable but also thorough and coherent inline documentation 
- [x] [Unit tests](https://r-pkgs.org/tests.html) when applicable
- [x] Complies with the [Hector code style guide](https://jgcri.github.io/hector/articles/manual/StyleGuide.html)
- [x] The PR passes automated testing suite