### PR TITLE
Rework makefiles

### DIFF
--- a/.github/workflows/cpp-testing.yaml
+++ b/.github/workflows/cpp-testing.yaml
@@ -26,15 +26,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install gtest
       # following https://github.com/bastianhjaeger/github_actions_gtest_example
-        run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib 
+        run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/local/lib 
       - name: Install Boost
         run: sudo apt install libboost-filesystem-dev libboost-system-dev
       - name: build and run
         run: |
           ver=`awk '/define.*BOOST_LIB_VERSION/ {print $3}' /usr/include/boost/version.hpp`
           echo Boost version $ver
-          GTLIB=/usr/lib
-          GTINC=
-          BOOSTLIB=/usr/local/lib BOOSTVERSION=$ver BOOSTROOT=/usr/include/boost 
-          make gtest
-          ./src/hector
+          GTLIB=/usr/local/lib
+          GTINC=/usr/local/include
+          BOOSTROOT=/usr/local/ 
+          make test

--- a/.github/workflows/unit-testing.yaml
+++ b/.github/workflows/unit-testing.yaml
@@ -1,6 +1,6 @@
 # Build the gtest Hector and run it
 
-name: googletest Hector
+name: Hector unit tests
 
 # Controls when the action will run.
 on:
@@ -30,10 +30,9 @@ jobs:
       - name: Install Boost
         run: sudo apt install libboost-filesystem-dev libboost-system-dev
       - name: build and run
+      # Don't really need to define BOOSTROOT and GTROOT, as these are the defaults
         run: |
-          ver=`awk '/define.*BOOST_LIB_VERSION/ {print $3}' /usr/include/boost/version.hpp`
-          echo Boost version $ver
-          GTLIB=/usr/local/lib
-          GTINC=/usr/local/include
-          BOOSTROOT=/usr/local/ 
-          make test
+          BOOSTROOT=/usr/local/
+          GTROOT=/usr/local/
+          make testing
+          ./src/Testing/hector-unit-tests

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -17,13 +17,7 @@ export HROOT
 
 ## ----------------------------------------------------
 ## Boost settings
-ifeq ($(strip $(BOOSTVERSION)),)
-	BOOSTVERSION	= 1_63_0
-endif
-ifeq ($(strip $(BOOSTROOT)),)
-	BOOSTROOT	= $(HOME)/src/boost_$(BOOSTVERSION)
-endif
-ifeq ($(strip $(BOOSTLIB)),)
+
 ## BOOSTROOT can be customized in the environment by compiling as:
 ##     BOOSTROOT=/path/to/boost_X_Y_Z make hector
 ## For package manager installs, this could be in any of the following
@@ -34,7 +28,15 @@ ifeq ($(strip $(BOOSTLIB)),)
 ## NOTE that if compiling BOOST from source, libraries may be
 ## installed in BOOSTROOT/stage/lib, in which case you may need to
 ## create a symbolic link from BOOSTROOT/lib to BOOSTROOT/stage/lib.
-BOOSTLIB = $(BOOSTROOT)/lib
+
+ifeq ($(strip $(BOOSTROOT)),)
+	BOOSTROOT	= /usr/local/
+endif
+ifeq ($(strip $(BOOSTINC)),)
+	BOOSTINC	= $(BOOSTROOT)/include
+endif
+ifeq ($(strip $(BOOSTLIB)),)
+	BOOSTLIB	= $(BOOSTROOT)/lib
 endif
 
 ## ----------------------------------------------------

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -1,6 +1,6 @@
 ## Makefile for Hector v3
 ## Original author: Robert Link
-## Revised by Ben Bond-Lamberty, 2021
+## Greatly revised by Ben Bond-Lamberty, 2021
 
 ## ----------------------------------------------------
 ## Build settings
@@ -45,9 +45,6 @@ ifeq ($(strip $(BOOSTLIB)),)
 	BOOSTLIB	= $(BOOSTROOT)/lib
 endif
 
-## ----------------------------------------------------
-## googletest settings
-
 ifeq ($(strip $(GTROOT)),)
 	GTROOT	= /usr/local/
 endif
@@ -66,8 +63,8 @@ export GTLIB GTINC
 CXXSRCS	= $(wildcard *.cpp)
 MAINS   = main.cpp main-api.cpp
 RCPPS   = $(wildcard rcpp_*.cpp) RcppExports.cpp
-## Remove the mains (main.cpp and main-api.cpp) as well as Rcpp files
-## The main file will be added later; WHICH main depends on the target 
+## Remove the mains, as well as Rcpp files, from source list
+## The main file will be added later; *which* main depends on the target 
 CXXSRCS := $(filter-out $(MAINS), $(CXXSRCS))
 CXXSRCS := $(filter-out $(RCPPS), $(CXXSRCS))
 CSRCS   = $(wildcard *.c)
@@ -92,14 +89,11 @@ testing: libhector.a
 # hector-api: libhector.a main-api.o
 # 	$(CXX) $(LDFLAGS) -o hector-api main-api.o -lhector -lgsl -lgslcblas -lm
 
-## Targets that do not literally name files
-.PHONY: clean 
+## Targets that do not literally name files; we always want them run when requested
+.PHONY: clean testing chkvar
 
 libhector.a: $(OBJS)
 	ar ru libhector.a *.o
-
-## top level directory objects
--include $(DEPS)
 
 clean:
 	-$(MAKE) -C testing clean

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -40,12 +40,15 @@ endif
 ## ----------------------------------------------------
 ## googletest settings
 
-ifeq ($(strip $(GTLIB)),)
-	## Our GitHub Actions script installs the gtest libraries in /usr/lib
-	GTLIB	= /usr/lib/
+ifeq ($(strip $(GTROOT)),)
+	GTROOT	= /usr/local/
 endif
-
-GTINC	= $(GTROOT)/include
+ifeq ($(strip $(GTINC)),)
+	GTINC	= $(GTROOT)/include
+endif
+ifeq ($(strip $(GTLIB)),)
+	GTLIB	= $(GTROOT)/lib
+endif
 
 export GTLIB GTINC
 
@@ -92,8 +95,8 @@ libhector.a: $(OBJS)
 -include $(DEPS)
 
 gtest:
-##	if [ ! -f $(GTROOT)/config.status ] ; then cd $(GTROOT) && ./configure; fi
-	$(MAKE) -C $(GTROOT)
+	if [ ! -f $(GTROOT)/config.status ] ; then cd $(GTROOT) && ./configure; fi
+	$(MAKE) -C Testing gtest
 
 clean:
 	-$(MAKE) -C testing clean
@@ -105,3 +108,5 @@ chkvar:
 	echo $(CSRCS)
 	echo $(OBJS)
 	echo $(INCLUDES)
+	echo $(BOOSTROOT)
+	echo $(GTROOT)

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -1,10 +1,16 @@
+## Makefile for Hector v3
+## Original author: Robert Link
+## Greatly revised by Ben Bond-Lamberty, 2021
+
+## ----------------------------------------------------
+## Build settings
 ifeq ($(strip $(CXX)),)
 	CXX      = g++
 endif 
 CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD -std=c++14 
 CFLAGS   = -g $(INCLUDES) $(OPTFLAGS) $(CCEXTRA) -MMD
 INCLUDES = -I"$(BOOSTROOT)" -I"$(HDRDIR)"
-WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn on warnings, turn off one particularly annoying one that infests Boost libs
+WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn off warnings, esp. one common in Boost files
 OPTFLAGS = -O3
 LDFLAGS	 = $(CXXPROF) -L"$(BOOSTLIB)" -L. -Wl,-rpath,"$(BOOSTLIB)"
 
@@ -54,12 +60,13 @@ endif
 
 export GTLIB GTINC
 
-
 ## ----------------------------------------------------
-## sources in the top level directory
+## Sources in the top level directory
 CXXSRCS	= $(wildcard *.cpp)
 MAINS   = main.cpp main-api.cpp
 RCPPS   = $(wildcard rcpp_*.cpp) RcppExports.cpp
+## Remove the mains (main.cpp and main-api.cpp) as well Rcpp files
+## They'll be included separately later as needed
 CXXSRCS := $(filter-out $(MAINS), $(CXXSRCS))
 CXXSRCS := $(filter-out $(RCPPS), $(CXXSRCS))
 CSRCS   = $(wildcard *.c)
@@ -67,9 +74,14 @@ OBJS	= $(CXXSRCS:.cpp=.o) $(CSRCS:.c=.o)
 DEPS	= $(CXXSRCS:.cpp=.d) $(CSRCS:.c=.d)
 
 ## ----------------------------------------------------
-## default target
+## Default target
 hector: libhector.a main.o
 	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lm -lboost_system -lboost_filesystem
+
+## Testing target
+testing: INCLUDES += -I$(GTINC)
+testing: libhector.a
+	$(MAKE) -C Testing hector-unit-tests
 
 ## alternate version that uses the capabilities needed for driving
 ## hector from an external source (e.g., an IAM)
@@ -85,11 +97,6 @@ hector: libhector.a main.o
 test: testing
 	cd testing && ./hector-unit-tests
 
-testing: INCLUDES += -I$(GTINC)
-##testing: components topdir
-testing: libhector.a
-	$(MAKE) -C Testing hector-unit-tests
-
 lib: libhector.a
 libhector.a: $(OBJS)
 	ar ru libhector.a *.o
@@ -103,10 +110,16 @@ clean:
 	-rm -rf build
 
 chkvar:
-	echo $(CXXSRCS)
-	echo $(CSRCS)
-	echo $(OBJS)
-	echo $(INCLUDES)
-	echo $(BOOSTROOT)
-	echo $(GTROOT)
+	@echo -n "CXXSRCS:"
+	@echo $(CXXSRCS)
+	@echo "CSRCS:"
+	@echo $(CSRCS)
+	@echo "OBJS:"
+	@echo $(OBJS)
+	@echo "INCLUDES:"
+	@echo $(INCLUDES)
+	@echo "BOOSTROOT:"
+	@echo $(BOOSTROOT)
+	@echo "GTROOT:"
+	@echo $(GTROOT)
 	-$(MAKE) -C testing chkvar

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -86,8 +86,9 @@ test: testing
 	cd testing && ./hector-unit-tests
 
 testing: INCLUDES += -I$(GTINC)
-testing: gtest components topdir
-	$(MAKE) -C testing hector-unit-tests
+##testing: components topdir
+testing: libhector.a
+	$(MAKE) -C Testing hector-unit-tests
 
 lib: libhector.a
 libhector.a: $(OBJS)
@@ -95,10 +96,6 @@ libhector.a: $(OBJS)
 
 ## top level directory objects
 -include $(DEPS)
-
-gtest:
-	if [ ! -f $(GTROOT)/config.status ] ; then cd $(GTROOT) && ./configure; fi
-	$(MAKE) -C Testing gtest
 
 clean:
 	-$(MAKE) -C testing clean
@@ -112,3 +109,4 @@ chkvar:
 	echo $(INCLUDES)
 	echo $(BOOSTROOT)
 	echo $(GTROOT)
+	-$(MAKE) -C testing chkvar

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -1,11 +1,11 @@
 ## Makefile for Hector v3
 ## Original author: Robert Link
-## Greatly revised by Ben Bond-Lamberty, 2021
+## Revised by Ben Bond-Lamberty, 2021
 
 ## ----------------------------------------------------
 ## Build settings
 ifeq ($(strip $(CXX)),)
-	CXX      = g++
+	CXX  = g++
 endif 
 CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD -std=c++14 
 CFLAGS   = -g $(INCLUDES) $(OPTFLAGS) $(CCEXTRA) -MMD
@@ -13,28 +13,28 @@ INCLUDES = -I"$(BOOSTROOT)" -I"$(HDRDIR)"
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn off warnings, esp. one common in Boost files
 OPTFLAGS = -O3
 LDFLAGS	 = $(CXXPROF) -L"$(BOOSTLIB)" -L. -Wl,-rpath,"$(BOOSTLIB)"
+HDRDIR	 = $(CURDIR)/../inst/include
 
+## These will be needed by the testing makefile
 export CXXFLAGS OPTFLAGS
 
-## project root
-HROOT	= $(CURDIR)/..
-HDRDIR	= $(HROOT)/inst/include
-export HROOT
-
 ## ----------------------------------------------------
-## Boost settings
+## Boost and Googletest settings
 
-## BOOSTROOT can be customized in the environment by compiling as:
+## BOOSTROOT and GTROOT can both be customized in the environment by e.g.:
 ##     BOOSTROOT=/path/to/boost_X_Y_Z make hector
-## For package manager installs, this could be in any of the following
-## locations (non-exhaustive list):
-## - /usr (boost libraries are in /usr/lib and headers/includes are in /usr/include)
-## - /usr/local
+## For package manager installs, this could be in locations such as:
+## - /usr - I.e., libraries are in /usr/local/lib and headers/includes are in /usr/local/include
+## - /usr/local - This is the default and used by the GitHub Actions YAML files
+##				  If libraries are installed here, there's nothing to do or define
 ## - /usr/local/Cellar/boost_<version_number> -- For MacOS HomeBrew installs
+##
 ## NOTE that if compiling BOOST from source, libraries may be
 ## installed in BOOSTROOT/stage/lib, in which case you may need to
 ## create a symbolic link from BOOSTROOT/lib to BOOSTROOT/stage/lib.
-
+##
+## If the header and library files aren't in include/ and lib/ subdirectories of
+## BOOSTROOT and/or GTROOT, you can also define BOOSTINC, BOOSTLIB, GTINC, and GTLIB.
 ifeq ($(strip $(BOOSTROOT)),)
 	BOOSTROOT	= /usr/local/
 endif
@@ -58,6 +58,7 @@ ifeq ($(strip $(GTLIB)),)
 	GTLIB	= $(GTROOT)/lib
 endif
 
+## These will be needed by the testing makefile
 export GTLIB GTINC
 
 ## ----------------------------------------------------
@@ -65,8 +66,8 @@ export GTLIB GTINC
 CXXSRCS	= $(wildcard *.cpp)
 MAINS   = main.cpp main-api.cpp
 RCPPS   = $(wildcard rcpp_*.cpp) RcppExports.cpp
-## Remove the mains (main.cpp and main-api.cpp) as well Rcpp files
-## They'll be included separately later as needed
+## Remove the mains (main.cpp and main-api.cpp) as well as Rcpp files
+## The main file will be added later; WHICH main depends on the target 
 CXXSRCS := $(filter-out $(MAINS), $(CXXSRCS))
 CXXSRCS := $(filter-out $(RCPPS), $(CXXSRCS))
 CSRCS   = $(wildcard *.c)
@@ -80,24 +81,20 @@ hector: libhector.a main.o
 
 ## Testing target
 testing: INCLUDES += -I$(GTINC)
-testing: libhector.a
+testing: libhector.a 
 	$(MAKE) -C Testing hector-unit-tests
 
-## alternate version that uses the capabilities needed for driving
-## hector from an external source (e.g., an IAM)
-## DO NOT BUILD THIS TARGET UNLESS YOU ARE TESTING HECTOR'S API
-## FUNCTIONALITY.  It uses some hard-coded emissions for testing and likely
+## Alternate version that uses the capabilities needed for driving
+## Hector from an external source (e.g., an IAM)
+## DO NOT BUILD THIS TARGET UNLESS YOU ARE TESTING HECTOR'S API FUNCTIONALITY. 
+## It uses some hard-coded emissions for testing and likely
 ## will not do what you want it to under all circumstances.
 # hector-api: libhector.a main-api.o
 # 	$(CXX) $(LDFLAGS) -o hector-api main-api.o -lhector -lgsl -lgslcblas -lm
 
 ## Targets that do not literally name files
-.PHONY: clean test gtest
+.PHONY: clean 
 
-test: testing
-	cd testing && ./hector-unit-tests
-
-lib: libhector.a
 libhector.a: $(OBJS)
 	ar ru libhector.a *.o
 

--- a/src/testing/Makefile
+++ b/src/testing/Makefile
@@ -5,7 +5,7 @@ SRCS	= $(wildcard *.cpp)
 
 ## ** TEMPORARY **
 ## the following files aren't working yet; remove them
-UNDONE = test_core.cpp test_csv_file_reader.cpp test_dependency_finder.cpp test_ini_to_core_reader.cpp
+UNDONE = test_core.cpp test_csv_file_reader.cpp test_dependency_finder.cpp
 SRCS := $(filter-out $(UNDONE), $(SRCS))
 
 OBJS	= $(SRCS:.cpp=.o)

--- a/src/testing/Makefile
+++ b/src/testing/Makefile
@@ -19,9 +19,9 @@ DEPS	= $(SRCS:.cpp=.d)
 LDFLAGS += -L$(GTLIB) -Wl,-L$(GTLIB),-L../
 
 ## ----------------------------------------------------
-
+## Default target
 hector-unit-tests: $(OBJS) ../libhector.a
-	$(CXX) $(LDFLAGS) -o hector-unit-tests $(OBJS) ../*.o -lhector -lgtest -lpthread -lm -lboost_system -lboost_filesystem
+	$(CXX) $(LDFLAGS) -o hector-unit-tests $(OBJS) ../libhector.a -lhector -lgtest -lpthread -lm -lboost_system -lboost_filesystem
 	
 clean:
 	-rm *.o

--- a/src/testing/Makefile
+++ b/src/testing/Makefile
@@ -1,17 +1,32 @@
 ## This Makefile is meant to be invoked recursively from the top level directory
 
+## This (SRCS) will include testing_main.cpp
 SRCS	= $(wildcard *.cpp)
+
+## temporary
+## the following files aren't working yet
+UNDONE = test_core.cpp test_csv_file_reader.cpp test_dependency_finder.cpp test_ini_to_core_reader.cpp
+SRCS := $(filter-out $(UNDONE), $(SRCS))
+## temporary
+
+CXXSRCS := $(filter-out $(MAINS), $(CXXSRCS))
+
 OBJS	= $(SRCS:.cpp=.o)
 DEPS	= $(SRCS:.cpp=.d)
 
-
 -include $(DEPS)
 
-LDFLAGS += -L$(GTLIB) -Wl,-rpath=$(GTLIB)
+LDFLAGS += -L$(GTLIB) -Wl,-L$(GTLIB),-L../
 
-hector-unit-tests: $(OBJS)
-	$(CXX) $(LDFLAGS) -o hector-unit-tests *.o ../build/*.o ../logger.o -lgtest -lpthread -lm
+## ----------------------------------------------------
 
+hector-unit-tests: $(OBJS) ../libhector.a
+	$(CXX) $(LDFLAGS) -o hector-unit-tests $(OBJS) ../*.o -lhector -lgtest -lpthread -lm -lboost_system -lboost_filesystem
+	
 clean:
 	-rm *.o
 	-rm hector-unit-tests
+
+chkvar:
+	echo "------- Testing"
+	echo $(OBJS)

--- a/src/testing/Makefile
+++ b/src/testing/Makefile
@@ -3,25 +3,21 @@
 ## This (SRCS) will include testing_main.cpp
 SRCS	= $(wildcard *.cpp)
 
-## temporary
-## the following files aren't working yet
+## ** TEMPORARY **
+## the following files aren't working yet; remove them
 UNDONE = test_core.cpp test_csv_file_reader.cpp test_dependency_finder.cpp test_ini_to_core_reader.cpp
 SRCS := $(filter-out $(UNDONE), $(SRCS))
-## temporary
-
-CXXSRCS := $(filter-out $(MAINS), $(CXXSRCS))
 
 OBJS	= $(SRCS:.cpp=.o)
 DEPS	= $(SRCS:.cpp=.d)
-
--include $(DEPS)
-
 LDFLAGS += -L$(GTLIB) -Wl,-L$(GTLIB),-L../
 
 ## ----------------------------------------------------
 ## Default target
 hector-unit-tests: $(OBJS) ../libhector.a
 	$(CXX) $(LDFLAGS) -o hector-unit-tests $(OBJS) ../libhector.a -lhector -lgtest -lpthread -lm -lboost_system -lboost_filesystem
+
+.PHONY: clean chkvar
 	
 clean:
 	-rm *.o

--- a/src/testing/Makefile
+++ b/src/testing/Makefile
@@ -28,5 +28,6 @@ clean:
 	-rm hector-unit-tests
 
 chkvar:
-	echo "------- Testing"
-	echo $(OBJS)
+	@echo "------- Testing"
+	@echo "OBJS:"
+	@echo $(OBJS)

--- a/src/testing/test_hreader.cpp
+++ b/src/testing/test_hreader.cpp
@@ -35,7 +35,7 @@ void test_hreader_writefile(  char* filename, string contents ) {
 }
 
 
-TEST( TestHreader, SimpleFile ) {
+TEST( HreaderTest, SimpleFile ) {
     
     char filename[] = "simple.ini";
     test_hreader_writefile( filename, 
@@ -58,7 +58,7 @@ TEST( TestHreader, SimpleFile ) {
     remove( filename );     // clean up
 }
 
-TEST( TestHreader, ComplexFile ) {
+TEST( HreaderTest, ComplexFile ) {
     
     char filename[] = "complex.ini";
     test_hreader_writefile( filename, 
@@ -105,7 +105,7 @@ TEST( TestHreader, ComplexFile ) {
     remove( filename );     // clean up    
 }
 
-TEST( TestHreader, CorruptSection ) {
+TEST( HreaderTest, CorruptSection ) {
     
     char filename[] = "corruptsection.ini";
     test_hreader_writefile( filename, 

--- a/src/testing/test_inih.cpp
+++ b/src/testing/test_inih.cpp
@@ -33,7 +33,7 @@ void test_inih_writefile(  char* filename, string contents ) {
 	}
 }
 
-TEST( TestINIH, SimpleFile ) {
+TEST( INIHTest, SimpleFile ) {
 
     char filename[] = "simple.ini";
     test_inih_writefile( filename, 
@@ -56,7 +56,7 @@ TEST( TestINIH, SimpleFile ) {
     remove( filename );     // clean up
 }
 
-TEST( TestINIH, ComplexFile ) {
+TEST( INIHTest, ComplexFile ) {
 
     char filename[] = "complex.ini";
     test_inih_writefile( filename, 
@@ -103,7 +103,7 @@ TEST( TestINIH, ComplexFile ) {
     remove( filename );     // clean up    
 }
 
-TEST( TestINIH, CorruptSection ) {
+TEST( INIHTest, CorruptSection ) {
     
     char filename[] = "corruptsection.ini";
     test_inih_writefile( filename, 

--- a/vignettes/manual/BuildHector.Rmd
+++ b/vignettes/manual/BuildHector.Rmd
@@ -59,9 +59,9 @@ Hector's mandatory dependencies are listed in the `DESCRIPTION` file under `Impo
 
 Hector can also be compiled as a standalone executable.
 Unlike the R package, this method of installation does not automatically pull in dependencies, so you will have to install them manually.
-Fortunately, Hector's only external dependency--Boost--is freely available under a GPL license.
 
-**Boost** is a free, peer-reviewed portable C++ source library, available at http://www.boost.org/.
+Hector's only external dependency, **Boost**, is a free, peer-reviewed portable
+C++ source library, available at http://www.boost.org/.
 Hector primarily uses Boost "header-only" libraries, which do not need to be compiled independently and only need to be extracted and included with the Hector source.
 However, Hector currently _does_ depend on two Boost libraries--`system` and `filesystem`--that require compilation. 
 
@@ -71,19 +71,24 @@ The Hector makefiles look for Boost libraries and headers in certain default
 locations, but those defaults can be overridden by setting the
 following environment variables:
 
-* `BOOSTROOT` (default `$(HOME)/src/boost_$(BOOSTVERSION)`).
-This variable should contain the full name of the directory created
-when you unpacked Boost. If you unpacked Boost in `$(HOME)/src`, then
-all you need to do is set the `BOOSTVERSION` variable (*q.v.* below) and leave this variable
-at its default value. If you unpacked Boost somewhere else (if you used [Homebrew](https://brew.sh/) to install Boost), or if you changed the name
-of the directory that was created when you unpacked it, then you will
-need to set this variable explicitly. 
+* `BOOSTROOT` (default `/usr/local/`).
+This variable should contain the full name of a directory with `include/` and
+`lib/` subdirectories that contain, respectively, the Boost header and library 
+files. If you installed Boost using a package manager, this is likely where
+it is. If you built Boost from source, or used [Homebrew](https://brew.sh/) to
+install Boost), then you will need to set this variable explicitly. 
 
-* `BOOSTVERSION` (default: `1_52_0`). This variable should contain the
-version number of the version of Boost that you installed.  The
-version number will appear in the name of the tar file you
-downloaded. The `BOOSTVERSION` variable is used in the default value of `BOOSTROOT` to determine the default installation
-directory. If you override the default value of `BOOSTROOT` you can ignore this variable.
+Alternatively, if the header and library locations are not subdirectories of
+a single directory, you can set `BOOSTINC` and `BOOSTLIB` variables to their 
+respective locations. In this case, `BOOSTROOT` is ignored.
+
+* `GTROOT` (default `/usr/local/`).
+This variable should contain the full name of a directory with `include/` and
+`lib/` subdirectories that contain, respectively, the Googletest header and library 
+files. Alternatively, if the header and library locations are not subdirectories of
+a single directory, you can set `GTINC` and `GTLIB` variables to their 
+locations. In this case, `GTROOT` is ignored. **Note that this is only needed
+if you want to run the Hector unit tests.** It's not needed for running the model.
 
 **Shared Library Search Path**
 
@@ -128,11 +133,17 @@ sure to unset `CXXPROF`, clean the build directories with `make clean`,
 and rebuild when you are ready to go back to
 production runs.
 
-
-Run Hector from the terminal with the command line. 
+Run Hector from the terminal:
 
 ```
 ./src/hector ./inst/input/name-of-ini.ini
+```
+
+To run build and run the Hector unit tests, type `make testing`
+and then
+
+```
+./src/Testing/hector-unit-tests
 ```
 
 ## Xcode (Mac OS X)
@@ -150,18 +161,19 @@ This means that developers and users can set these paths without overwriting eac
 * You will need to set several custom paths (Preferences -> Locations -> Custom Paths): `BOOSTLIB`, `BOOSTROOT`, and `HECTORDIR`. These are the Boost runtime library, the Boost root under which the headers can be found in `boost/`, and the runtime working directory for the model (the repository root).
 * If you want to build Hector's testing framework (the `hector-tests` target; this is optional and only relevant for C++ developers) add GTEST and GTESTLIB custom paths to Xcode; these are analogous to their Boost counterparts. You will need to install [googletest](https://github.com/google/googletest) on your machine.
 
-
 At this point you should be ready to go:
 
 * Build the project, making sure you're building the `hector` target.
 * Run!
 * To run a different scenario, change the current Scheme settings (Scheme->Edit Scheme) and modify or add a command-line argument (*Arguments* tab, e.g. "./inst/input/hector_rcp45.ini").
 
+The Xcode profile file includes a `hector-tests` target that builds the unit
+testing framework described above.
+
 Xcode Resources 
 
 * [Xcode Schemes](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ManagingSchemes.html)
 * [Xcode Debugging](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/debugging_with_xcode/chapters/debugging_tools.html)
-
 
 ## Visual Studio Code (Windows)
 
@@ -170,7 +182,6 @@ Xcode Resources
 * Download the [Hector zip file](https://github.com/JGCRI/hector/archive/master.zip) or check out the repository using Git.
 * Open Hector in the visual studio code IDE, build Hector with Terminal --> Run Build Task or with a `make hector` call in VSC terminal window. 
 * Run --> Start Debugging or Run Without Debugging or with `./src/hector ./inst/input/name-of-ini.ini` in the VSC terminal window. 
-
 
 ## Visual Studio
 


### PR DESCRIPTION
Hector's makefiles were unclear, had lots of unneeded cruft, and didn't completely work (e.g. the `testing` target wouldn't be invalidated by changes to unit testing code). This PR heavily reworks them for clarity and concision.