### PR TITLE
Clean up inline code comments

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,7 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/src/oh_component.cpp
+++ b/src/oh_component.cpp
@@ -11,7 +11,6 @@
  *  Created by Corinne on 11/20/2014.
  *
  */
-// changed back to using only concentrations
 
 #include <math.h>
 #include "oh_component.hpp"

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -1130,9 +1130,6 @@ void SimpleNbox::record_state(double t)
     H_LOG(logger, Logger::DEBUG) << "record_state: recorded tempferts = " << tempferts[SNBOX_DEFAULT_BIOME]
                                  << " at time= " << t << std::endl;
 
-    // ocean model appears to be controlled by the N-box model.  Seems
-    // like it makes swapping out for another model a nightmare, but
-    // that's where we're at.
     omodel->record_state(t);
 
 }


### PR DESCRIPTION
Minor change 

Recently we identified some confusing inline comments this PR removes them now so we won't forget about it. 

Also reverts the pkgdown deployment back to the mac osx platform, while it is less efficient this only runs after a pr has been merged into the master. 