### PR TITLE
Fix unit handling in sendmessage

### DIFF
--- a/R/biome.R
+++ b/R/biome.R
@@ -26,10 +26,10 @@ create_biome <- function(core, biome,
                          f_nppd = 0.60,
                          f_litterd = 0.98) {
   create_biome_impl(core, biome)
-  setvar(core, 0, VEG_C(biome), veg_c0, "PgC")
-  setvar(core, 0, DETRITUS_C(biome), detritus_c0, "PgC")
-  setvar(core, 0, SOIL_C(biome), soil_c0, "PgC")
-  setvar(core, NA, NPP_FLUX0(biome), npp_flux0, "PgC/yr")
+  setvar(core, 0, VEG_C(biome), veg_c0, "Pg C")
+  setvar(core, 0, DETRITUS_C(biome), detritus_c0, "Pg C")
+  setvar(core, 0, SOIL_C(biome), soil_c0, "Pg C")
+  setvar(core, NA, NPP_FLUX0(biome), npp_flux0, "Pg C/yr")
   setvar(core, NA, WARMINGFACTOR(biome), warmingfactor, NA)
   setvar(core, NA, BETA(biome), beta, NA)
   setvar(core, NA, Q10_RH(biome), q10_rh, NA)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -5,6 +5,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // GETDATA
 String GETDATA();
 RcppExport SEXP _hector_GETDATA() {

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -304,10 +304,14 @@ DataFrame sendmessage(Environment core, String msgtype, String capability, Numer
         utype = Hector::unitval::parseUnitsName(unitstr);
     }
     catch(h_exception e) {
-        // std::stringstream emsg;
-        // emsg << "sendmessage: invalid unit type: " << unitstr;
-        // Rcpp::stop(emsg.str());
-        utype = Hector::U_UNDEFINED;
+        // Units need to be specified in setData and incorrect pr missing units will throw an error
+        if (msgstr=="setData"){
+            std::stringstream emsg;
+            emsg << "invalid unit type '" << unitstr << "' in input " << capstr;
+            Rcpp::stop(emsg.str());
+        } else {  // Units do not need to be specified in getData, setting to undefined
+            utype = Hector::U_UNDEFINED;
+        }
     }
 
     NumericVector valueout(N);

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -305,7 +305,7 @@ DataFrame sendmessage(Environment core, String msgtype, String capability, Numer
     }
     catch(h_exception e) {
         // Units need to be specified in setData and incorrect pr missing units will throw an error
-        if (msgstr=="setData"){
+        if (msgstr==M_SETDATA){
             std::stringstream emsg;
             emsg << "invalid unit type '" << unitstr << "' in input " << capstr;
             Rcpp::stop(emsg.str());

--- a/tests/testthat/test_set_get_data.R
+++ b/tests/testthat/test_set_get_data.R
@@ -60,5 +60,5 @@ for (v in emissions) {
 }
 
 test_that("Setting variable with invalid unit throws an error", {
-  expect_error(setvar(hc, year, VEG_C(), 500, "boogedyboo"))
+  expect_error(setvar(hc, year, VEG_C(), 500, "boogedyboo"), regex = "invalid unit")
 })

--- a/tests/testthat/test_set_get_data.R
+++ b/tests/testthat/test_set_get_data.R
@@ -60,4 +60,6 @@ for (v in emissions) {
   })
 }
 
-expect_error(setvar(hc, year, VEG_C(), 500, "boogedyboo"))
+test_that("Setting variable with invalid unit throws an error", {
+  expect_error(setvar(hc, year, VEG_C(), 500, "boogedyboo"))
+})

--- a/tests/testthat/test_set_get_data.R
+++ b/tests/testthat/test_set_get_data.R
@@ -53,8 +53,11 @@ for (v in emissions) {
   test_that(paste0("Setting variable ", v, " works."), {
     expect_silent(setvar(hc, year, v, val, unit))
   })
+            
   invisible(run(hc, year))
   test_that(paste0("Getting variable ", v, " works."), {
     expect_equal(fetchvars(hc, year, v)[["value"]], val)
   })
 }
+
+expect_error(setvar(hc, year, VEG_C(), 500, "boogedyboo"))

--- a/tests/testthat/test_set_get_data.R
+++ b/tests/testthat/test_set_get_data.R
@@ -53,7 +53,6 @@ for (v in emissions) {
   test_that(paste0("Setting variable ", v, " works."), {
     expect_silent(setvar(hc, year, v, val, unit))
   })
-            
   invisible(run(hc, year))
   test_that(paste0("Getting variable ", v, " works."), {
     expect_equal(fetchvars(hc, year, v)[["value"]], val)


### PR DESCRIPTION
@mbins and I added behavior to stop if invalid units passed to sendmessage in rcpp_hector.cpp when setting data, and to set to unitless if invalid or missing units passed when getting data. Also fixed invalid units in biome.R (it was using PgC instead of Pg C). One thing to look at though is that we hard coded the string for "setData" into the if statement - not sure if there's a better way to do it that C++ recognizes. 

Closes #327 

