### PR TITLE
Return full ocean tracking information to atmosphere

### DIFF
--- a/inst/include/ocean_component.hpp
+++ b/inst/include/ocean_component.hpp
@@ -76,8 +76,9 @@ public:
     void stashCValues( double t, const double c[] );
     void record_state(double t);
     void set_atmosphere_sources( fluxpool atm ) { atmosphere_cpool = atm; };
-    fluxpool get_surface_pools() const;
-    
+    fluxpool get_oaflux() const;
+    fluxpool get_aoflux() const;
+
 private:
     virtual unitval getData( const std::string& varName,
                             const double date );

--- a/inst/include/oceanbox.hpp
+++ b/inst/include/oceanbox.hpp
@@ -71,7 +71,8 @@ public:
 	void set_carbon( const unitval C );
 	fluxpool get_carbon() const { return carbon; };
     fluxpool get_oa_flux() const { return oa_flux; };
-    
+    fluxpool get_ao_flux() const { return ao_flux; };
+
 	void add_carbon( fluxpool C );
 
     void start_tracking();

--- a/src/ocean_component.cpp
+++ b/src/ocean_component.cpp
@@ -529,11 +529,19 @@ void OceanComponent::slowparameval( double t, const double c[] ) {
 }
 
 //------------------------------------------------------------------------------
-/*! \brief   Return the ocean-atmosphere flux (really, its source map) to simpleNbox
+/*! \brief   Return the ocean-to-atmosphere flux to simpleNbox
 *  \returns           The two ocean-atmosphere fluxpools added together
 */
-fluxpool OceanComponent::get_surface_pools() const {
-    return surfaceLL.get_carbon() + surfaceHL.get_carbon();
+fluxpool OceanComponent::get_oaflux() const {
+    return surfaceLL.get_oa_flux() + surfaceHL.get_oa_flux();
+}
+
+//------------------------------------------------------------------------------
+/*! \brief   Return the atmosphere-to-ocean flux to simpleNbox
+*  \returns           The two atmosphere-ocean fluxpools added together
+*/
+fluxpool OceanComponent::get_aoflux() const {
+    return surfaceLL.get_ao_flux() + surfaceHL.get_ao_flux();
 }
 
 //------------------------------------------------------------------------------
@@ -574,6 +582,7 @@ void OceanComponent::stashCValues( double t, const double c[] ) {
     surfaceLL.atmosphere_flux = surfaceLL.atmosphere_flux + adjustment;
     
     // Separate the one net flux (can be positive or negative) into the two fluxpool fluxes (always positive)
+    // This updates oa_flux and ao_flux within the two ocean boxes
     surfaceHL.separate_surface_fluxes(atmosphere_cpool);
     surfaceLL.separate_surface_fluxes(atmosphere_cpool);
     

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -227,25 +227,15 @@ void SimpleNbox::stashCValues( double t, const double c[] )
     fluxpool ccs_flux = atmos_c.flux_from_fluxpool(ccs_untracked);
 
     // current ocean fluxes
-    const unitval ocean_carbon = core->sendMessage( M_GETDATA, D_OCEAN_C);
     omodel->stashCValues( t, c );   // tell ocean model to store new C values (and compute final surface fluxes)
-    unitval ocean_atmos = unitval(c[SNBOX_OCEAN] - ocean_carbon.value(U_PGC), U_PGC);
-    fluxpool ocean_surface = omodel->get_surface_pools();
+    // ...and now get those fluxes (and their source maps, if tracking)
+    fluxpool oa_flux = omodel->get_oaflux();
+    fluxpool ao_flux = omodel->get_aoflux();
     
-    fluxpool oa_flux(0.0, U_PGC);
-    fluxpool ao_flux(0.0, U_PGC);
-    if(ocean_atmos > 0){
-        ao_flux = atmos_c.flux_from_unitval(ocean_atmos);
-        oa_flux = ocean_surface.flux_from_fluxpool(oa_flux); // i.e., 0
-    } else {
-        oa_flux = ocean_surface.flux_from_unitval(-ocean_atmos);
-        ao_flux = atmos_c.flux_from_fluxpool(ao_flux); // i.e., 0
-    }
-
+    // Land-use change uptake from atmosphere to veg, detritus, and soil
     fluxpool luc_e_untracked = luc_emission(t, in_spinup) * yf;
     fluxpool luc_u_untracked = luc_uptake(t, in_spinup) * yf;
 
-    // Land-use change uptake from atmosphere to veg, detritus, and soil
     fluxpool luc_fav_flux = atmos_c.flux_from_fluxpool(luc_u_untracked * f_lucv);
     fluxpool luc_fad_flux = atmos_c.flux_from_fluxpool(luc_u_untracked * f_lucd);
     fluxpool luc_fas_flux = atmos_c.flux_from_fluxpool(luc_u_untracked * ( 1 - f_lucv - f_lucd ));


### PR DESCRIPTION
We were just using the net ocean-atmosphere flux to do tracking, which meant that nothing from the ocean was making it into the atmosphere (in tracking terms) once anthropogenic forcing took hold. This PR fixes that, and as a bonus, simplifies and clarifies the code! 

![oceanfix](https://user-images.githubusercontent.com/1956468/128946292-1027aab4-076e-4e05-bbcf-46122c01ee39.png)

See https://github.com/NatanelHa/Ha-Hector-Internship/issues/6