### PR TITLE
Reconcile and clean up biome/variable naming

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -16,6 +16,11 @@ SETDATA <- function() {
     .Call('_hector_SETDATA', PACKAGE = 'hector')
 }
 
+#' @describeIn msgtype Character used to separate biome from variable name
+BIOME_SPLIT_CHAR <- function() {
+    .Call('_hector_BIOME_SPLIT_CHAR', PACKAGE = 'hector')
+}
+
 #' @describeIn loglevels Set logging at 'debug' level.
 #' @export
 LL_DEBUG <- function() {
@@ -1090,11 +1095,6 @@ FLUX_INTERIOR <- function() {
 #' @export
 HEAT_FLUX <- function() {
     .Call('_hector_HEAT_FLUX', PACKAGE = 'hector')
-}
-
-#' @describeIn msgtype Character used to separate biome from variable name
-BIOME_SPLIT_CHAR <- function() {
-    .Call('_hector_BIOME_SPLIT_CHAR', PACKAGE = 'hector')
 }
 
 newcore_impl <- function(inifile, loglevel, suppresslogging, name) {

--- a/R/biome.R
+++ b/R/biome.R
@@ -132,7 +132,7 @@ get_biome_inits <- function(core, biome) {
   ))[, -1]
   current_data <- rbind.data.frame(current_data_1, current_data_2)
   current_values <- current_data[["value"]]
-  names(current_values) <- gsub(paste0(biome, "."), "",
+  names(current_values) <- gsub(paste0(biome, BIOME_SPLIT_CHAR()), "",
     current_data[["variable"]],
     fixed = TRUE
   )

--- a/inst/include/avisitor.hpp
+++ b/inst/include/avisitor.hpp
@@ -83,36 +83,4 @@ AVisitor::~AVisitor() {
 
 }
 
-
-// Macros used by both csv_tracking_visitor and csv_outputstream_visitor
-
-// TODO: consolidate these macros into the two MESSAGE ones,
-// and shift string literals to D_xxxx definitions
-
-// Macro to send a variable with associated unitval units to some output stream
-// Takes s (stream), c (component), xname (variable name), x (output variable)
-#define STREAM_UNITVAL( s, c, xname, x ) { \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-
-// Macro to send a variable with associated unitval units to some output stream
-// This uses new sendMessage interface in imodel_component
-// Takes s (stream), c (component), xname (variable name)
-#define STREAM_MESSAGE( s, c, xname ) { \
-unitval x = c->sendMessage( M_GETDATA, xname ); \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-// Macro for date-dependent variables
-// Takes s (stream), c (component), xname (variable name), date
-#define STREAM_MESSAGE_DATE( s, c, xname, date ) { \
-unitval x = c->sendMessage( M_GETDATA, xname, message_data( date ) ); \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-
 #endif // AVISITOR_H

--- a/inst/include/avisitor.hpp
+++ b/inst/include/avisitor.hpp
@@ -83,4 +83,36 @@ AVisitor::~AVisitor() {
 
 }
 
+
+// Macros used by both csv_tracking_visitor and csv_outputstream_visitor
+
+// TODO: consolidate these macros into the two MESSAGE ones,
+// and shift string literals to D_xxxx definitions
+
+// Macro to send a variable with associated unitval units to some output stream
+// Takes s (stream), c (component), xname (variable name), x (output variable)
+#define STREAM_UNITVAL( s, c, xname, x ) { \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+
+// Macro to send a variable with associated unitval units to some output stream
+// This uses new sendMessage interface in imodel_component
+// Takes s (stream), c (component), xname (variable name)
+#define STREAM_MESSAGE( s, c, xname ) { \
+unitval x = c->sendMessage( M_GETDATA, xname ); \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+// Macro for date-dependent variables
+// Takes s (stream), c (component), xname (variable name), date
+#define STREAM_MESSAGE_DATE( s, c, xname, date ) { \
+unitval x = c->sendMessage( M_GETDATA, xname, message_data( date ) ); \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+
 #endif // AVISITOR_H

--- a/inst/include/csv_tracking_visitor.hpp
+++ b/inst/include/csv_tracking_visitor.hpp
@@ -4,10 +4,10 @@
    Please see the accompanying file LICENSE.md for additional licensing
    information.
 */
-#ifndef CSV_FLUXPOOL_VISITOR_H
-#define CSV_FLUXPOOL_VISITOR_H
+#ifndef CSV_TRACKING_VISITOR_H
+#define CSV_TRACKING_VISITOR_H
 /*
- *  csv_fluxpool_visitor.h
+ *  csv_tracking_visitor.h
  *  hector
  *
  *  Created by Skylar Gering on 21 January 2021.
@@ -68,4 +68,4 @@ private:
 
 }
 
-#endif // CSV_FLUXPOOL_VISITOR_H
+#endif // CSV_TRACKING_VISITOR_H

--- a/project_files/Xcode/hector.xcodeproj/project.pbxproj
+++ b/project_files/Xcode/hector.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		277D29DC2683669E003177A2 /* libboost_system.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 277D29DA2683669E003177A2 /* libboost_system.dylib */; };
 		277D29DD2683669E003177A2 /* libboost_filesystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 277D29DB2683669E003177A2 /* libboost_filesystem.dylib */; };
 		27808CF12615CEFA00BE8B90 /* libgtest.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 27808CF02615CEFA00BE8B90 /* libgtest.dylib */; };
-		27962905268F237300333AA3 /* csv_fluxpool_visitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962904268F237200333AA3 /* csv_fluxpool_visitor.cpp */; };
+		27962905268F237300333AA3 /* csv_tracking_visitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962904268F237200333AA3 /* csv_tracking_visitor.cpp */; };
 		27962908268F23CB00333AA3 /* simpleNbox-runtime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962907268F23CB00333AA3 /* simpleNbox-runtime.cpp */; };
 		27962909268F241100333AA3 /* simpleNbox-runtime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962907268F23CB00333AA3 /* simpleNbox-runtime.cpp */; };
 		27A02A5E2615CBB800AF9BFA /* halocarbon_component.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C231261511C5005DE26D /* halocarbon_component.cpp */; };
@@ -84,7 +84,7 @@
 		27B2C26E261511C8005DE26D /* carbon-cycle-model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C24B261511C8005DE26D /* carbon-cycle-model.cpp */; };
 		27B2C270261511C8005DE26D /* spline_forsythe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C24D261511C8005DE26D /* spline_forsythe.cpp */; };
 		27B2C271261511C8005DE26D /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C24E261511C8005DE26D /* main.cpp */; };
-		27F2613726B55617004BDD47 /* csv_fluxpool_visitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962904268F237200333AA3 /* csv_fluxpool_visitor.cpp */; };
+		27F2613726B55617004BDD47 /* csv_tracking_visitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962904268F237200333AA3 /* csv_tracking_visitor.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -144,8 +144,8 @@
 		277D29DA2683669E003177A2 /* libboost_system.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_system.dylib; path = ../../../../../../../../../usr/local/lib/libboost_system.dylib; sourceTree = "<group>"; };
 		277D29DB2683669E003177A2 /* libboost_filesystem.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_filesystem.dylib; path = ../../../../../../../../../usr/local/lib/libboost_filesystem.dylib; sourceTree = "<group>"; };
 		27808CF02615CEFA00BE8B90 /* libgtest.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libgtest.dylib; path = ../../../../../../../../../usr/local/lib/libgtest.dylib; sourceTree = "<group>"; };
-		27962903268F235500333AA3 /* csv_fluxpool_visitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = csv_fluxpool_visitor.hpp; path = ../../inst/include/csv_fluxpool_visitor.hpp; sourceTree = "<group>"; };
-		27962904268F237200333AA3 /* csv_fluxpool_visitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = csv_fluxpool_visitor.cpp; path = ../../src/csv_fluxpool_visitor.cpp; sourceTree = "<group>"; };
+		27962903268F235500333AA3 /* csv_tracking_visitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = csv_tracking_visitor.hpp; path = ../../inst/include/csv_tracking_visitor.hpp; sourceTree = "<group>"; };
+		27962904268F237200333AA3 /* csv_tracking_visitor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = csv_tracking_visitor.cpp; path = ../../src/csv_tracking_visitor.cpp; sourceTree = "<group>"; };
 		27962906268F239A00333AA3 /* fluxpool.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = fluxpool.hpp; path = ../../inst/include/fluxpool.hpp; sourceTree = "<group>"; };
 		27962907268F23CB00333AA3 /* simpleNbox-runtime.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "simpleNbox-runtime.cpp"; path = "../../src/simpleNbox-runtime.cpp"; sourceTree = "<group>"; };
 		27A02A882615CBB800AF9BFA /* hector-tests */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "hector-tests"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -298,9 +298,9 @@
 				27B2C2092615112D005DE26D /* component_data.hpp */,
 				27B2C2142615112E005DE26D /* component_names.hpp */,
 				27B2C2202615112E005DE26D /* core.hpp */,
-				27962903268F235500333AA3 /* csv_fluxpool_visitor.hpp */,
 				27B2C2112615112E005DE26D /* csv_outputstream_visitor.hpp */,
 				27B2C2022615112D005DE26D /* csv_table_reader.hpp */,
+				27962903268F235500333AA3 /* csv_tracking_visitor.hpp */,
 				27B2C21E2615112E005DE26D /* dependency_finder.hpp */,
 				27B2C2182615112E005DE26D /* dummy_model_component.hpp */,
 				27962906268F239A00333AA3 /* fluxpool.hpp */,
@@ -344,9 +344,9 @@
 				27B2C22F261511C5005DE26D /* carbon-cycle-solver.cpp */,
 				27B2C22C261511C5005DE26D /* ch4_component.cpp */,
 				27B2C23D261511C6005DE26D /* core.cpp */,
-				27962904268F237200333AA3 /* csv_fluxpool_visitor.cpp */,
 				27B2C23F261511C7005DE26D /* csv_outputstream_visitor.cpp */,
 				27B2C234261511C6005DE26D /* csv_table_reader.cpp */,
+				27962904268F237200333AA3 /* csv_tracking_visitor.cpp */,
 				27B2C23C261511C6005DE26D /* dependency_finder.cpp */,
 				27B2C249261511C7005DE26D /* dummy_model_component.cpp */,
 				27B2C230261511C5005DE26D /* forcing_component.cpp */,
@@ -496,7 +496,7 @@
 				27B2C256261511C8005DE26D /* o3_component.cpp in Sources */,
 				27B2C25D261511C8005DE26D /* n2o_component.cpp in Sources */,
 				27B2C250261511C8005DE26D /* h_reader.cpp in Sources */,
-				27962905268F237300333AA3 /* csv_fluxpool_visitor.cpp in Sources */,
+				27962905268F237300333AA3 /* csv_tracking_visitor.cpp in Sources */,
 				27B2C253261511C8005DE26D /* forcing_component.cpp in Sources */,
 				27B2C26C261511C8005DE26D /* dummy_model_component.cpp in Sources */,
 				27B2C261261511C8005DE26D /* oceanbox.cpp in Sources */,
@@ -511,7 +511,7 @@
 				27A02A602615CBB800AF9BFA /* ocean_csys.cpp in Sources */,
 				27A02A612615CBB800AF9BFA /* core.cpp in Sources */,
 				27A02A622615CBB800AF9BFA /* INIReader.cpp in Sources */,
-				27F2613726B55617004BDD47 /* csv_fluxpool_visitor.cpp in Sources */,
+				27F2613726B55617004BDD47 /* csv_tracking_visitor.cpp in Sources */,
 				27A02A632615CBB800AF9BFA /* so2_component.cpp in Sources */,
 				27A02A642615CBB800AF9BFA /* oc_component.cpp in Sources */,
 				273FC39F26A3570B00D5303E /* test_fluxpool.cpp in Sources */,

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -30,6 +30,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// BIOME_SPLIT_CHAR
+String BIOME_SPLIT_CHAR();
+RcppExport SEXP _hector_BIOME_SPLIT_CHAR() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(BIOME_SPLIT_CHAR());
+    return rcpp_result_gen;
+END_RCPP
+}
 // LL_DEBUG
 int LL_DEBUG();
 RcppExport SEXP _hector_LL_DEBUG() {
@@ -1820,16 +1830,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// BIOME_SPLIT_CHAR
-String BIOME_SPLIT_CHAR();
-RcppExport SEXP _hector_BIOME_SPLIT_CHAR() {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    rcpp_result_gen = Rcpp::wrap(BIOME_SPLIT_CHAR());
-    return rcpp_result_gen;
-END_RCPP
-}
 // newcore_impl
 Environment newcore_impl(String inifile, int loglevel, bool suppresslogging, String name);
 RcppExport SEXP _hector_newcore_impl(SEXP inifileSEXP, SEXP loglevelSEXP, SEXP suppressloggingSEXP, SEXP nameSEXP) {
@@ -1980,6 +1980,7 @@ END_RCPP
 static const R_CallMethodDef CallEntries[] = {
     {"_hector_GETDATA", (DL_FUNC) &_hector_GETDATA, 0},
     {"_hector_SETDATA", (DL_FUNC) &_hector_SETDATA, 0},
+    {"_hector_BIOME_SPLIT_CHAR", (DL_FUNC) &_hector_BIOME_SPLIT_CHAR, 0},
     {"_hector_LL_DEBUG", (DL_FUNC) &_hector_LL_DEBUG, 0},
     {"_hector_LL_NOTICE", (DL_FUNC) &_hector_LL_NOTICE, 0},
     {"_hector_LL_WARNING", (DL_FUNC) &_hector_LL_WARNING, 0},
@@ -2158,7 +2159,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_hector_FLUX_MIXED", (DL_FUNC) &_hector_FLUX_MIXED, 0},
     {"_hector_FLUX_INTERIOR", (DL_FUNC) &_hector_FLUX_INTERIOR, 0},
     {"_hector_HEAT_FLUX", (DL_FUNC) &_hector_HEAT_FLUX, 0},
-    {"_hector_BIOME_SPLIT_CHAR", (DL_FUNC) &_hector_BIOME_SPLIT_CHAR, 0},
     {"_hector_newcore_impl", (DL_FUNC) &_hector_newcore_impl, 4},
     {"_hector_shutdown", (DL_FUNC) &_hector_shutdown, 1},
     {"_hector_reset", (DL_FUNC) &_hector_reset, 2},

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -34,7 +34,7 @@
 #include "h_util.hpp"
 #include "simpleNbox.hpp"
 #include "avisitor.hpp"
-#include "csv_fluxpool_visitor.hpp"
+#include "csv_tracking_visitor.hpp"
 
 namespace Hector {
 

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -138,14 +138,14 @@ void CSVOutputStreamVisitor::visit( SimpleNbox* c ) {
     if( c->veg_c.size() > 1 ) {
         SimpleNbox::fluxpool_stringmap::const_iterator it;
         for( it = c->veg_c.begin(); it != c->veg_c.end(); it++ ) {
-            std::string biome = ( *it ).first + SNBOX_PARSECHAR;
-            STREAM_UNITVAL( csvFile, c, biome + D_NPP, c->npp( biome ) );
-            STREAM_UNITVAL( csvFile, c, biome + D_RH, c->rh( biome ) );
-            STREAM_UNITVAL( csvFile, c, biome + D_VEGC, c->veg_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome + D_DETRITUSC, c->detritus_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome + D_SOILC, c->soil_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome + D_TEMPFERTD, unitval( c->tempfertd[ biome ], U_UNITLESS ) );
-            STREAM_UNITVAL( csvFile, c, biome + D_TEMPFERTS, unitval( c->tempferts[ biome ], U_UNITLESS ) );
+            std::string biome = ( *it ).first;
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_NPP, c->npp( biome ) );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_RH, c->rh( biome ) );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_VEGC, c->veg_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_DETRITUSC, c->detritus_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_SOILC, c->soil_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTD, unitval( c->tempfertd[ biome ], U_UNITLESS ) );
+            STREAM_UNITVAL( csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTS, unitval( c->tempferts[ biome ], U_UNITLESS ) );
         }
     }
 }

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -97,6 +97,35 @@ void CSVOutputStreamVisitor::visit( Core* c ) {
     core = c;
 }
 
+// TODO: consolidate these macros into the two MESSAGE ones,
+// and shift string literals to D_xxxx definitions
+
+// Macro to send a variable with associated unitval units to some output stream
+// Takes s (stream), c (component), xname (variable name), x (output variable)
+#define STREAM_UNITVAL( s, c, xname, x ) { \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+
+// Macro to send a variable with associated unitval units to some output stream
+// This uses new sendMessage interface in imodel_component
+// Takes s (stream), c (component), xname (variable name)
+#define STREAM_MESSAGE( s, c, xname ) { \
+unitval x = c->sendMessage( M_GETDATA, xname ); \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+// Macro for date-dependent variables
+// Takes s (stream), c (component), xname (variable name), date
+#define STREAM_MESSAGE_DATE( s, c, xname, date ) { \
+unitval x = c->sendMessage( M_GETDATA, xname, message_data( date ) ); \
+s << linestamp() << c->getComponentName() << DELIMITER \
+<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
+<< x.unitsName() << std::endl; \
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CSVOutputStreamVisitor::visit( ForcingComponent* c ) {
@@ -166,7 +195,8 @@ void CSVOutputStreamVisitor::visit( TemperatureComponent* c ) {
     STREAM_MESSAGE( csvFile, c, D_FLUX_MIXED );
     STREAM_MESSAGE( csvFile, c, D_FLUX_INTERIOR )
 	STREAM_MESSAGE(csvFile, c, D_HEAT_FLUX );
-    }
+}
+
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CSVOutputStreamVisitor::visit( OceanComponent* c ) {
@@ -200,8 +230,6 @@ void CSVOutputStreamVisitor::visit( OceanComponent* c ) {
         STREAM_MESSAGE( csvFile, c, D_REVELLE_LL );
     }
 }
-
-
 
 //------------------------------------------------------------------------------
 // documentation is inherited

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -97,36 +97,6 @@ void CSVOutputStreamVisitor::visit( Core* c ) {
     core = c;
 }
 
-// TODO: have to consolidate these macros into the two MESSAGE ones,
-// and shift string literals to D_xxxx definitions
-
-// Macro to send a variable with associated unitval units to some output stream
-// Takes s (stream), c (component), xname (variable name), x (output variable)
-#define STREAM_UNITVAL( s, c, xname, x ) { \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-
-// Macro to send a variable with associated unitval units to some output stream
-// This uses new sendMessage interface in imodel_component
-// Takes s (stream), c (component), xname (variable name), date
-#define STREAM_MESSAGE( s, c, xname ) { \
-unitval x = c->sendMessage( M_GETDATA, xname ); \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-// Macro for date-dependent variables
-// Takes s (stream), c (component), xname (variable name), date
-#define STREAM_MESSAGE_DATE( s, c, xname, date ) { \
-unitval x = c->sendMessage( M_GETDATA, xname, message_data( date ) ); \
-s << linestamp() << c->getComponentName() << DELIMITER \
-<< xname << DELIMITER << x.value( x.units() ) << DELIMITER \
-<< x.unitsName() << std::endl; \
-}
-
-
 //------------------------------------------------------------------------------
 // documentation is inherited
 void CSVOutputStreamVisitor::visit( ForcingComponent* c ) {
@@ -163,7 +133,7 @@ void CSVOutputStreamVisitor::visit( SimpleNbox* c ) {
     STREAM_MESSAGE( csvFile, c, D_SOILC );
     STREAM_MESSAGE( csvFile, c, D_EARTHC );
 
-    // Biome-specific outputs: <variable>.<biome>
+    // Biome-specific outputs: <biome>.<variable>
     if( c->veg_c.size() > 1 ) {
         SimpleNbox::fluxpool_stringmap::const_iterator it;
         for( it = c->veg_c.begin(); it != c->veg_c.end(); it++ ) {

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -122,6 +122,7 @@ void CSVOutputStreamVisitor::visit( SimpleNbox* c ) {
     if( !core->outputEnabled( c->getComponentName() ) ) return;
 
     // Global outputs
+    // Note if there are multiple biomes, these values will be totals, summed across all biomes
     STREAM_MESSAGE( csvFile, c, D_LAND_CFLUX );
     STREAM_MESSAGE( csvFile, c, D_NPP );
     STREAM_MESSAGE( csvFile, c, D_RH );
@@ -137,14 +138,14 @@ void CSVOutputStreamVisitor::visit( SimpleNbox* c ) {
     if( c->veg_c.size() > 1 ) {
         SimpleNbox::fluxpool_stringmap::const_iterator it;
         for( it = c->veg_c.begin(); it != c->veg_c.end(); it++ ) {
-            std::string biome = ( *it ).first;
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_NPP, c->npp( biome ) );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_RH, c->rh( biome ) );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_VEGC, c->veg_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_DETRITUSC, c->detritus_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_SOILC, c->soil_c[ biome ] );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_TEMPFERTD, unitval( c->tempfertd[ biome ], U_UNITLESS ) );
-            STREAM_UNITVAL( csvFile, c, biome+"."+D_TEMPFERTS, unitval( c->tempferts[ biome ], U_UNITLESS ) );
+            std::string biome = ( *it ).first + SNBOX_PARSECHAR;
+            STREAM_UNITVAL( csvFile, c, biome + D_NPP, c->npp( biome ) );
+            STREAM_UNITVAL( csvFile, c, biome + D_RH, c->rh( biome ) );
+            STREAM_UNITVAL( csvFile, c, biome + D_VEGC, c->veg_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + D_DETRITUSC, c->detritus_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + D_SOILC, c->soil_c[ biome ] );
+            STREAM_UNITVAL( csvFile, c, biome + D_TEMPFERTD, unitval( c->tempfertd[ biome ], U_UNITLESS ) );
+            STREAM_UNITVAL( csvFile, c, biome + D_TEMPFERTS, unitval( c->tempferts[ biome ], U_UNITLESS ) );
         }
     }
 }

--- a/src/csv_tracking_visitor.cpp
+++ b/src/csv_tracking_visitor.cpp
@@ -5,7 +5,7 @@
    information.
 */
 /*
- *  csv_fluxpool_visitor.cpp
+ *  csv_tracking_visitor.cpp
  *  hector
  *
  *  Created by Skylar Gering on 21 January 2021.
@@ -17,7 +17,7 @@
 #include "core.hpp"
 #include "simpleNbox.hpp"
 #include "ocean_component.hpp"
-#include "csv_fluxpool_visitor.hpp"
+#include "csv_tracking_visitor.hpp"
 #include "unitval.hpp"
 #include "h_util.hpp"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@
 #include "h_reader.hpp"
 #include "ini_to_core_reader.hpp"
 #include "csv_outputstream_visitor.hpp"
-#include "csv_fluxpool_visitor.hpp"
+#include "csv_tracking_visitor.hpp"
 
 #include "unitval.hpp"
 

--- a/src/rcpp_constants.cpp
+++ b/src/rcpp_constants.cpp
@@ -34,6 +34,13 @@ String SETDATA() {
 return M_SETDATA;
 }
 
+//' @describeIn msgtype Character used to separate biome from variable name
+// [[Rcpp::export]]
+String BIOME_SPLIT_CHAR() {
+   return SNBOX_PARSECHAR;
+}
+
+
 /* Logging levels */
 
 //' @describeIn loglevels Set logging at 'debug' level.
@@ -1125,7 +1132,7 @@ String BETA(String biome = "") {
   // `Rcpp::String` has a `+=` method, but no `+` method, so have to use
   // this clunky workaround.
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_BETA;
   return out;
 }
@@ -1137,7 +1144,7 @@ String BETA(String biome = "") {
 String Q10_RH(String biome = "") {
   if (biome == "") return D_Q10_RH;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_Q10_RH;
   return out;
 }
@@ -1150,7 +1157,7 @@ String Q10_RH(String biome = "") {
 String WARMINGFACTOR(String biome = "") {
   if (biome == "") return D_WARMINGFACTOR;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_WARMINGFACTOR;
   return out;
 }
@@ -1169,7 +1176,7 @@ String CO2_CONSTRAIN() {
 String F_NPPV(String biome = "") {
   if (biome == "") return D_F_NPPV;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_F_NPPV;
   return out;
 }
@@ -1181,7 +1188,7 @@ String F_NPPV(String biome = "") {
 String F_NPPD(String biome = "") {
   if (biome == "") return D_F_NPPD;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_F_NPPD;
   return out;
 }
@@ -1193,7 +1200,7 @@ String F_NPPD(String biome = "") {
 String F_LITTERD(String biome = "") {
   if (biome == "") return D_F_LITTERD;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_F_LITTERD;
   return out;
 }
@@ -1219,7 +1226,7 @@ return D_F_LUCD;
 String VEG_C(String biome = "") {
   if (biome == "") return D_VEGC;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_VEGC;
   return out;
 }
@@ -1231,7 +1238,7 @@ String VEG_C(String biome = "") {
 String DETRITUS_C(String biome = "") {
   if (biome == "") return D_DETRITUSC;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_DETRITUSC;
   return out;
 }
@@ -1243,7 +1250,7 @@ String DETRITUS_C(String biome = "") {
 String SOIL_C(String biome = "") {
   if (biome == "") return D_SOILC;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_SOILC;
   return out;
 }
@@ -1256,7 +1263,7 @@ String SOIL_C(String biome = "") {
 String NPP_FLUX0(String biome = "") {
   if (biome == "") return D_NPP_FLUX0;
   String out = biome;
-  out += ".";
+  out += BIOME_SPLIT_CHAR();
   out += D_NPP_FLUX0;
   return out;
 }
@@ -1400,10 +1407,4 @@ return D_FLUX_INTERIOR;
 // [[Rcpp::export]]
 String HEAT_FLUX() {
 return D_HEAT_FLUX;
-}
-
-//' @describeIn msgtype Character used to separate biome from variable name
-// [[Rcpp::export]]
-String BIOME_SPLIT_CHAR() {
-return SNBOX_PARSECHAR;
 }

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -182,10 +182,12 @@ void SimpleNbox::setData( const std::string &varName,
     }
 
     if (data.isVal) {
-        H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << "." << varNameParsed << "[" << data.date << "]=" << data.value_unitval << std::endl;
+        H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << SNBOX_PARSECHAR
+        << varNameParsed << "[" << data.date << "]=" << data.value_unitval << std::endl;
     }
     else {
-        H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << "." << varNameParsed << "[" << data.date << "]=" << data.value_str << std::endl;
+        H_LOG( logger, Logger::DEBUG ) << "Setting " << biome << SNBOX_PARSECHAR
+        << varNameParsed << "[" << data.date << "]=" << data.value_str << std::endl;
     }
     try {
         // Initial pools
@@ -215,19 +217,19 @@ void SimpleNbox::setData( const std::string &varName,
             // `reset` (which includes code like `veg_c = veg_c_tv.get(t)`).
             
             // Data are coming in as unitvals, but change to fluxpools
-            veg_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, "veg_c_" + biome);
+            veg_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, varName);
             if (data.date != Core::undefinedIndex()) {
                 veg_c_tv.set(data.date, veg_c);
             }
         }
         else if( varNameParsed == D_DETRITUSC ) {
-            detritus_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, "detritus_c_" + biome);
+            detritus_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, varName);
             if (data.date != Core::undefinedIndex()) {
                 detritus_c_tv.set(data.date, detritus_c);
             }
         }
         else if( varNameParsed == D_SOILC ) {
-            soil_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, "soil_c_" + biome);
+            soil_c[ biome ] = fluxpool(data.getUnitval( U_PGC ).value(U_PGC), U_PGC, false, varName);
             if (data.date != Core::undefinedIndex()) {
                 soil_c_tv.set(data.date, soil_c);
             }

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -630,11 +630,11 @@ void SimpleNbox::createBiome(const std::string& biome)
     H_ASSERT(!has_biome( biome ), errmsg);
 
     // Initialize new pools
-    veg_c[ biome ] = fluxpool(0, U_PGC, false, "veg_c_"+biome);
+    veg_c[ biome ] = fluxpool(0, U_PGC, false, D_VEGC);
     add_biome_to_ts(veg_c_tv, biome, veg_c.at( biome ));
-    detritus_c[ biome ] = fluxpool(0, U_PGC, false, "detritus_c_" + biome);
+    detritus_c[ biome ] = fluxpool(0, U_PGC, false, D_DETRITUSC);
     add_biome_to_ts(detritus_c_tv, biome, detritus_c.at( biome ));
-    soil_c[ biome ] = fluxpool(0, U_PGC, false, "soil_c_" + biome);
+    soil_c[ biome ] = fluxpool(0, U_PGC, false, D_SOILC);
     add_biome_to_ts(soil_c_tv, biome, soil_c.at( biome ));
 
     npp_flux0[ biome ] = fluxpool(0, U_PGC_YR);

--- a/tests/testthat/test_biome.R
+++ b/tests/testthat/test_biome.R
@@ -9,7 +9,7 @@ rcp45 <- function() {
   )
 }
 
-test_that("Hector runs with multiple biomes created via INI file.", {
+test_that("Hector runs with multiple biomes created via INI file", {
   string2core <- function(ini_string, name, ini_file = NULL) {
     if (is.null(ini_file)) {
       ini_file <- tempfile()


### PR DESCRIPTION
* Reconcile biome/variable name convention between visitors
* Use a single constant instead of "." literals in both C++ and R code

Closes #499 