### PR TITLE
Update the Visual Studio project file

### DIFF
--- a/project_files/VS/hector-lib.vcxproj
+++ b/project_files/VS/hector-lib.vcxproj
@@ -23,7 +23,9 @@
     <ClInclude Include="..\..\inst\include\ch4_component.hpp" />
     <ClInclude Include="..\..\inst\include\component_data.hpp" />
     <ClInclude Include="..\..\inst\include\component_names.hpp" />
+    <ClInclude Include="..\..\inst\include\csv_tracking_visitor.hpp" />
     <ClInclude Include="..\..\inst\include\dummy_model_component.hpp" />
+    <ClInclude Include="..\..\inst\include\fluxpool.hpp" />
     <ClInclude Include="..\..\inst\include\forcing_component.hpp" />
     <ClInclude Include="..\..\inst\include\halocarbon_component.hpp" />
     <ClInclude Include="..\..\inst\include\imodel_component.hpp" />
@@ -32,7 +34,6 @@
     <ClInclude Include="..\..\inst\include\ocean_component.hpp" />
     <ClInclude Include="..\..\inst\include\oc_component.hpp" />
     <ClInclude Include="..\..\inst\include\oh_component.hpp" />
-    <ClInclude Include="..\..\inst\include\onelineocean_component.hpp" />
     <ClInclude Include="..\..\inst\include\slr_component.hpp" />
     <ClInclude Include="..\..\inst\include\so2_component.hpp" />
     <ClInclude Include="..\..\inst\include\temperature_component.hpp" />
@@ -59,11 +60,11 @@
     <ClInclude Include="..\..\inst\include\simpleNbox.hpp" />
     <ClInclude Include="..\..\inst\include\avisitor.hpp" />
     <ClInclude Include="..\..\inst\include\csv_outputstream_visitor.hpp" />
-    <ClInclude Include="..\..\inst\include\csv_output_visitor.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\bc_component.cpp" />
     <ClCompile Include="..\..\src\ch4_component.cpp" />
+    <ClCompile Include="..\..\src\csv_tracking_visitor.cpp" />
     <ClCompile Include="..\..\src\dummy_model_component.cpp" />
     <ClCompile Include="..\..\src\forcing_component.cpp" />
     <ClCompile Include="..\..\src\halocarbon_component.cpp" />
@@ -72,7 +73,7 @@
     <ClCompile Include="..\..\src\ocean_component.cpp" />
     <ClCompile Include="..\..\src\oc_component.cpp" />
     <ClCompile Include="..\..\src\oh_component.cpp" />
-    <ClCompile Include="..\..\src\onelineocean_component.cpp" />
+    <ClCompile Include="..\..\src\simpleNbox-runtime.cpp" />
     <ClCompile Include="..\..\src\slr_component.cpp" />
     <ClCompile Include="..\..\src\so2_component.cpp" />
     <ClCompile Include="..\..\src\temperature_component.cpp" />
@@ -93,7 +94,6 @@
     <ClCompile Include="..\..\src\ocean_csys.cpp" />
     <ClCompile Include="..\..\src\simpleNbox.cpp" />
     <ClCompile Include="..\..\src\csv_outputstream_visitor.cpp" />
-    <ClCompile Include="..\..\src\csv_output_visitor.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{88489C16-7642-48BB-B36C-C4B9507A1DE2}</ProjectGuid>
@@ -105,20 +105,20 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/project_files/VS/hector-lib.vcxproj
+++ b/project_files/VS/hector-lib.vcxproj
@@ -211,7 +211,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../../../../../libs/boost-lib;..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(BOOSTROOT);..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/project_files/VS/hector-lib.vcxproj
+++ b/project_files/VS/hector-lib.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,92 +19,93 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\headers\components\bc_component.hpp" />
-    <ClInclude Include="..\..\headers\components\ch4_component.hpp" />
-    <ClInclude Include="..\..\headers\components\component_data.hpp" />
-    <ClInclude Include="..\..\headers\components\component_names.hpp" />
-    <ClInclude Include="..\..\headers\components\dummy_model_component.hpp" />
-    <ClInclude Include="..\..\headers\components\forcing_component.hpp" />
-    <ClInclude Include="..\..\headers\components\halocarbon_component.hpp" />
-    <ClInclude Include="..\..\headers\components\imodel_component.hpp" />
-    <ClInclude Include="..\..\headers\components\n2o_component.hpp" />
-    <ClInclude Include="..\..\headers\components\o3_component.hpp" />
-    <ClInclude Include="..\..\headers\components\ocean_component.hpp" />
-    <ClInclude Include="..\..\headers\components\oc_component.hpp" />
-    <ClInclude Include="..\..\headers\components\oh_component.hpp" />
-    <ClInclude Include="..\..\headers\components\onelineocean_component.hpp" />
-    <ClInclude Include="..\..\headers\components\slr_component.hpp" />
-    <ClInclude Include="..\..\headers\components\so2_component.hpp" />
-    <ClInclude Include="..\..\headers\components\temperature_component.hpp" />
-    <ClInclude Include="..\..\headers\core\carbon-cycle-solver.hpp" />
-    <ClInclude Include="..\..\headers\core\core.hpp" />
-    <ClInclude Include="..\..\headers\core\dependency_finder.hpp" />
-    <ClInclude Include="..\..\headers\core\ivisitable.hpp" />
-    <ClInclude Include="..\..\headers\core\logger.hpp" />
-    <ClInclude Include="..\..\headers\data\h_interpolator.hpp" />
-    <ClInclude Include="..\..\headers\data\message_data.hpp" />
-    <ClInclude Include="..\..\headers\data\tseries.hpp" />
-    <ClInclude Include="..\..\headers\data\unitval.hpp" />
-    <ClInclude Include="..\..\headers\hector.hpp" />
-    <ClInclude Include="..\..\headers\h_exception.hpp" />
-    <ClInclude Include="..\..\headers\h_util.hpp" />
-    <ClInclude Include="..\..\headers\input\csv_table_reader.hpp" />
-    <ClInclude Include="..\..\headers\input\h_reader.hpp" />
-    <ClInclude Include="..\..\headers\input\inih\ini.h" />
-    <ClInclude Include="..\..\headers\input\inih\INIReader.h" />
-    <ClInclude Include="..\..\headers\input\ini_to_core_reader.hpp" />
-    <ClInclude Include="..\..\headers\models\carbon-cycle-model.hpp" />
-    <ClInclude Include="..\..\headers\models\oceanbox.hpp" />
-    <ClInclude Include="..\..\headers\models\ocean_csys.hpp" />
-    <ClInclude Include="..\..\headers\models\simpleNbox.hpp" />
-    <ClInclude Include="..\..\headers\visitors\avisitor.hpp" />
-    <ClInclude Include="..\..\headers\visitors\csv_outputstream_visitor.hpp" />
-    <ClInclude Include="..\..\headers\visitors\csv_output_visitor.hpp" />
+    <ClInclude Include="..\..\inst\include\bc_component.hpp" />
+    <ClInclude Include="..\..\inst\include\ch4_component.hpp" />
+    <ClInclude Include="..\..\inst\include\component_data.hpp" />
+    <ClInclude Include="..\..\inst\include\component_names.hpp" />
+    <ClInclude Include="..\..\inst\include\dummy_model_component.hpp" />
+    <ClInclude Include="..\..\inst\include\forcing_component.hpp" />
+    <ClInclude Include="..\..\inst\include\halocarbon_component.hpp" />
+    <ClInclude Include="..\..\inst\include\imodel_component.hpp" />
+    <ClInclude Include="..\..\inst\include\n2o_component.hpp" />
+    <ClInclude Include="..\..\inst\include\o3_component.hpp" />
+    <ClInclude Include="..\..\inst\include\ocean_component.hpp" />
+    <ClInclude Include="..\..\inst\include\oc_component.hpp" />
+    <ClInclude Include="..\..\inst\include\oh_component.hpp" />
+    <ClInclude Include="..\..\inst\include\onelineocean_component.hpp" />
+    <ClInclude Include="..\..\inst\include\slr_component.hpp" />
+    <ClInclude Include="..\..\inst\include\so2_component.hpp" />
+    <ClInclude Include="..\..\inst\include\temperature_component.hpp" />
+    <ClInclude Include="..\..\inst\include\carbon-cycle-solver.hpp" />
+    <ClInclude Include="..\..\inst\include\core.hpp" />
+    <ClInclude Include="..\..\inst\include\dependency_finder.hpp" />
+    <ClInclude Include="..\..\inst\include\ivisitable.hpp" />
+    <ClInclude Include="..\..\inst\include\logger.hpp" />
+    <ClInclude Include="..\..\inst\include\h_interpolator.hpp" />
+    <ClInclude Include="..\..\inst\include\message_data.hpp" />
+    <ClInclude Include="..\..\inst\include\tseries.hpp" />
+    <ClInclude Include="..\..\inst\include\unitval.hpp" />
+    <ClInclude Include="..\..\inst\include\hector.hpp" />
+    <ClInclude Include="..\..\inst\include\h_exception.hpp" />
+    <ClInclude Include="..\..\inst\include\h_util.hpp" />
+    <ClInclude Include="..\..\inst\include\csv_table_reader.hpp" />
+    <ClInclude Include="..\..\inst\include\h_reader.hpp" />
+    <ClInclude Include="..\..\inst\include\ini.h" />
+    <ClInclude Include="..\..\inst\include\INIReader.h" />
+    <ClInclude Include="..\..\inst\include\ini_to_core_reader.hpp" />
+    <ClInclude Include="..\..\inst\include\carbon-cycle-model.hpp" />
+    <ClInclude Include="..\..\inst\include\oceanbox.hpp" />
+    <ClInclude Include="..\..\inst\include\ocean_csys.hpp" />
+    <ClInclude Include="..\..\inst\include\simpleNbox.hpp" />
+    <ClInclude Include="..\..\inst\include\avisitor.hpp" />
+    <ClInclude Include="..\..\inst\include\csv_outputstream_visitor.hpp" />
+    <ClInclude Include="..\..\inst\include\csv_output_visitor.hpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\source\components\bc_component.cpp" />
-    <ClCompile Include="..\..\source\components\ch4_component.cpp" />
-    <ClCompile Include="..\..\source\components\dummy_model_component.cpp" />
-    <ClCompile Include="..\..\source\components\forcing_component.cpp" />
-    <ClCompile Include="..\..\source\components\halocarbon_component.cpp" />
-    <ClCompile Include="..\..\source\components\n2o_component.cpp" />
-    <ClCompile Include="..\..\source\components\o3_component.cpp" />
-    <ClCompile Include="..\..\source\components\ocean_component.cpp" />
-    <ClCompile Include="..\..\source\components\oc_component.cpp" />
-    <ClCompile Include="..\..\source\components\oh_component.cpp" />
-    <ClCompile Include="..\..\source\components\onelineocean_component.cpp" />
-    <ClCompile Include="..\..\source\components\slr_component.cpp" />
-    <ClCompile Include="..\..\source\components\so2_component.cpp" />
-    <ClCompile Include="..\..\source\components\temperature_component.cpp" />
-    <ClCompile Include="..\..\source\core\carbon-cycle-solver.cpp" />
-    <ClCompile Include="..\..\source\core\core.cpp" />
-    <ClCompile Include="..\..\source\core\dependency_finder.cpp" />
-    <ClCompile Include="..\..\source\core\logger.cpp" />
-    <ClCompile Include="..\..\source\data\h_interpolator.cpp" />
-    <ClCompile Include="..\..\source\data\spline_forsythe.cpp" />
-    <ClCompile Include="..\..\source\data\unitval.cpp" />
-    <ClCompile Include="..\..\source\input\csv_table_reader.cpp" />
-    <ClCompile Include="..\..\source\input\h_reader.cpp" />
-    <ClCompile Include="..\..\source\input\inih\ini.c" />
-    <ClCompile Include="..\..\source\input\inih\INIReader.cpp" />
-    <ClCompile Include="..\..\source\input\ini_to_core_reader.cpp" />
-    <ClCompile Include="..\..\source\models\carbon-cycle-model.cpp" />
-    <ClCompile Include="..\..\source\models\oceanbox.cpp" />
-    <ClCompile Include="..\..\source\models\ocean_csys.cpp" />
-    <ClCompile Include="..\..\source\models\simpleNbox.cpp" />
-    <ClCompile Include="..\..\source\visitors\csv_outputstream_visitor.cpp" />
-    <ClCompile Include="..\..\source\visitors\csv_output_visitor.cpp" />
+    <ClCompile Include="..\..\src\bc_component.cpp" />
+    <ClCompile Include="..\..\src\ch4_component.cpp" />
+    <ClCompile Include="..\..\src\dummy_model_component.cpp" />
+    <ClCompile Include="..\..\src\forcing_component.cpp" />
+    <ClCompile Include="..\..\src\halocarbon_component.cpp" />
+    <ClCompile Include="..\..\src\n2o_component.cpp" />
+    <ClCompile Include="..\..\src\o3_component.cpp" />
+    <ClCompile Include="..\..\src\ocean_component.cpp" />
+    <ClCompile Include="..\..\src\oc_component.cpp" />
+    <ClCompile Include="..\..\src\oh_component.cpp" />
+    <ClCompile Include="..\..\src\onelineocean_component.cpp" />
+    <ClCompile Include="..\..\src\slr_component.cpp" />
+    <ClCompile Include="..\..\src\so2_component.cpp" />
+    <ClCompile Include="..\..\src\temperature_component.cpp" />
+    <ClCompile Include="..\..\src\carbon-cycle-solver.cpp" />
+    <ClCompile Include="..\..\src\core.cpp" />
+    <ClCompile Include="..\..\src\dependency_finder.cpp" />
+    <ClCompile Include="..\..\src\logger.cpp" />
+    <ClCompile Include="..\..\src\h_interpolator.cpp" />
+    <ClCompile Include="..\..\src\spline_forsythe.cpp" />
+    <ClCompile Include="..\..\src\unitval.cpp" />
+    <ClCompile Include="..\..\src\csv_table_reader.cpp" />
+    <ClCompile Include="..\..\src\h_reader.cpp" />
+    <ClCompile Include="..\..\src\ini.c" />
+    <ClCompile Include="..\..\src\INIReader.cpp" />
+    <ClCompile Include="..\..\src\ini_to_core_reader.cpp" />
+    <ClCompile Include="..\..\src\carbon-cycle-model.cpp" />
+    <ClCompile Include="..\..\src\oceanbox.cpp" />
+    <ClCompile Include="..\..\src\ocean_csys.cpp" />
+    <ClCompile Include="..\..\src\simpleNbox.cpp" />
+    <ClCompile Include="..\..\src\csv_outputstream_visitor.cpp" />
+    <ClCompile Include="..\..\src\csv_output_visitor.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{88489C16-7642-48BB-B36C-C4B9507A1DE2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hector</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -117,13 +118,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -165,7 +166,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -178,7 +179,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../../../../../libs/boost-lib;..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../libs/boost-lib;..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -193,7 +194,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -210,7 +211,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../../../../../libs/boost-lib;..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../../../../../libs/boost-lib;..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/project_files/VS/hector-lib.vcxproj.filters
+++ b/project_files/VS/hector-lib.vcxproj.filters
@@ -53,226 +53,226 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\headers\components\bc_component.hpp">
+    <ClInclude Include="..\..\inst\include\bc_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\ch4_component.hpp">
+    <ClInclude Include="..\..\inst\include\ch4_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\component_data.hpp">
+    <ClInclude Include="..\..\inst\include\component_data.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\component_names.hpp">
+    <ClInclude Include="..\..\inst\include\component_names.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\dummy_model_component.hpp">
+    <ClInclude Include="..\..\inst\include\dummy_model_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\forcing_component.hpp">
+    <ClInclude Include="..\..\inst\include\forcing_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\halocarbon_component.hpp">
+    <ClInclude Include="..\..\inst\include\halocarbon_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\imodel_component.hpp">
+    <ClInclude Include="..\..\inst\include\imodel_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\n2o_component.hpp">
+    <ClInclude Include="..\..\inst\include\n2o_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\o3_component.hpp">
+    <ClInclude Include="..\..\inst\include\o3_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\oc_component.hpp">
+    <ClInclude Include="..\..\inst\include\oc_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\ocean_component.hpp">
+    <ClInclude Include="..\..\inst\include\ocean_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\oh_component.hpp">
+    <ClInclude Include="..\..\inst\include\oh_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\onelineocean_component.hpp">
+    <ClInclude Include="..\..\inst\include\onelineocean_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\slr_component.hpp">
+    <ClInclude Include="..\..\inst\include\slr_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\components\so2_component.hpp">
+    <ClInclude Include="..\..\inst\include\so2_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\core\carbon-cycle-solver.hpp">
+    <ClInclude Include="..\..\inst\include\carbon-cycle-solver.hpp">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\core\core.hpp">
+    <ClInclude Include="..\..\inst\include\core.hpp">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\core\dependency_finder.hpp">
+    <ClInclude Include="..\..\inst\include\dependency_finder.hpp">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\core\ivisitable.hpp">
+    <ClInclude Include="..\..\inst\include\ivisitable.hpp">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\core\logger.hpp">
+    <ClInclude Include="..\..\inst\include\logger.hpp">
       <Filter>Header Files\core</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\data\h_interpolator.hpp">
+    <ClInclude Include="..\..\inst\include\h_interpolator.hpp">
       <Filter>Header Files\data</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\data\message_data.hpp">
+    <ClInclude Include="..\..\inst\include\message_data.hpp">
       <Filter>Header Files\data</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\data\tseries.hpp">
+    <ClInclude Include="..\..\inst\include\tseries.hpp">
       <Filter>Header Files\data</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\data\unitval.hpp">
+    <ClInclude Include="..\..\inst\include\unitval.hpp">
       <Filter>Header Files\data</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\input\csv_table_reader.hpp">
+    <ClInclude Include="..\..\inst\include\csv_table_reader.hpp">
       <Filter>Header Files\input</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\input\h_reader.hpp">
+    <ClInclude Include="..\..\inst\include\h_reader.hpp">
       <Filter>Header Files\input</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\input\ini_to_core_reader.hpp">
+    <ClInclude Include="..\..\inst\include\ini_to_core_reader.hpp">
       <Filter>Header Files\input</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\input\inih\ini.h">
-      <Filter>Header Files\input\inih</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\headers\input\inih\INIReader.h">
-      <Filter>Header Files\input\inih</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\headers\models\carbon-cycle-model.hpp">
+    <ClInclude Include="..\..\inst\include\carbon-cycle-model.hpp">
       <Filter>Header Files\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\models\ocean_csys.hpp">
+    <ClInclude Include="..\..\inst\include\ocean_csys.hpp">
       <Filter>Header Files\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\models\oceanbox.hpp">
+    <ClInclude Include="..\..\inst\include\oceanbox.hpp">
       <Filter>Header Files\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\models\simpleNbox.hpp">
+    <ClInclude Include="..\..\inst\include\simpleNbox.hpp">
       <Filter>Header Files\models</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\visitors\avisitor.hpp">
+    <ClInclude Include="..\..\inst\include\avisitor.hpp">
       <Filter>Header Files\visitors</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\visitors\csv_output_visitor.hpp">
+    <ClInclude Include="..\..\inst\include\csv_output_visitor.hpp">
       <Filter>Header Files\visitors</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\visitors\csv_outputstream_visitor.hpp">
+    <ClInclude Include="..\..\inst\include\csv_outputstream_visitor.hpp">
       <Filter>Header Files\visitors</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\headers\h_exception.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\headers\h_util.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\headers\hector.hpp">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\headers\components\temperature_component.hpp">
+    <ClInclude Include="..\..\inst\include\temperature_component.hpp">
       <Filter>Header Files\components</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\hector.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\h_exception.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\h_util.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\ini.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\INIReader.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\source\components\bc_component.cpp">
+    <ClCompile Include="..\..\src\bc_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\ch4_component.cpp">
+    <ClCompile Include="..\..\src\ch4_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\dummy_model_component.cpp">
+    <ClCompile Include="..\..\src\dummy_model_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\forcing_component.cpp">
+    <ClCompile Include="..\..\src\forcing_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\halocarbon_component.cpp">
+    <ClCompile Include="..\..\src\halocarbon_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\n2o_component.cpp">
+    <ClCompile Include="..\..\src\n2o_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\o3_component.cpp">
+    <ClCompile Include="..\..\src\o3_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\oc_component.cpp">
+    <ClCompile Include="..\..\src\oc_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\ocean_component.cpp">
+    <ClCompile Include="..\..\src\ocean_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\oh_component.cpp">
+    <ClCompile Include="..\..\src\oh_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\onelineocean_component.cpp">
+    <ClCompile Include="..\..\src\onelineocean_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\slr_component.cpp">
+    <ClCompile Include="..\..\src\slr_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\so2_component.cpp">
+    <ClCompile Include="..\..\src\so2_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\core\carbon-cycle-solver.cpp">
+    <ClCompile Include="..\..\src\carbon-cycle-solver.cpp">
       <Filter>Source Files\core</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\core\core.cpp">
+    <ClCompile Include="..\..\src\core.cpp">
       <Filter>Source Files\core</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\core\dependency_finder.cpp">
+    <ClCompile Include="..\..\src\dependency_finder.cpp">
       <Filter>Source Files\core</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\core\logger.cpp">
+    <ClCompile Include="..\..\src\logger.cpp">
       <Filter>Source Files\core</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\data\h_interpolator.cpp">
+    <ClCompile Include="..\..\src\h_interpolator.cpp">
       <Filter>Source Files\data</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\data\spline_forsythe.cpp">
+    <ClCompile Include="..\..\src\spline_forsythe.cpp">
       <Filter>Source Files\data</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\data\unitval.cpp">
+    <ClCompile Include="..\..\src\unitval.cpp">
       <Filter>Source Files\data</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\input\csv_table_reader.cpp">
+    <ClCompile Include="..\..\src\csv_table_reader.cpp">
       <Filter>Source Files\input</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\input\h_reader.cpp">
+    <ClCompile Include="..\..\src\h_reader.cpp">
       <Filter>Source Files\input</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\input\ini_to_core_reader.cpp">
+    <ClCompile Include="..\..\src\ini_to_core_reader.cpp">
       <Filter>Source Files\input</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\input\inih\ini.c">
+    <ClCompile Include="..\..\src\ini.c">
       <Filter>Source Files\input\inih</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\input\inih\INIReader.cpp">
-      <Filter>Source Files\input\inih</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\source\models\carbon-cycle-model.cpp">
+    <ClCompile Include="..\..\src\carbon-cycle-model.cpp">
       <Filter>Source Files\models</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\models\ocean_csys.cpp">
+    <ClCompile Include="..\..\src\ocean_csys.cpp">
       <Filter>Source Files\models</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\models\oceanbox.cpp">
+    <ClCompile Include="..\..\src\oceanbox.cpp">
       <Filter>Source Files\models</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\models\simpleNbox.cpp">
+    <ClCompile Include="..\..\src\simpleNbox.cpp">
       <Filter>Source Files\models</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\visitors\csv_output_visitor.cpp">
+    <ClCompile Include="..\..\src\csv_output_visitor.cpp">
       <Filter>Source Files\visitors</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\visitors\csv_outputstream_visitor.cpp">
+    <ClCompile Include="..\..\src\csv_outputstream_visitor.cpp">
       <Filter>Source Files\visitors</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\components\temperature_component.cpp">
+    <ClCompile Include="..\..\src\temperature_component.cpp">
       <Filter>Source Files\components</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\INIReader.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/project_files/VS/hector-lib.vcxproj.filters
+++ b/project_files/VS/hector-lib.vcxproj.filters
@@ -92,9 +92,6 @@
     <ClInclude Include="..\..\inst\include\oh_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\inst\include\onelineocean_component.hpp">
-      <Filter>Header Files\components</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\inst\include\slr_component.hpp">
       <Filter>Header Files\components</Filter>
     </ClInclude>
@@ -152,9 +149,6 @@
     <ClInclude Include="..\..\inst\include\avisitor.hpp">
       <Filter>Header Files\visitors</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\inst\include\csv_output_visitor.hpp">
-      <Filter>Header Files\visitors</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\inst\include\csv_outputstream_visitor.hpp">
       <Filter>Header Files\visitors</Filter>
     </ClInclude>
@@ -175,6 +169,12 @@
     </ClInclude>
     <ClInclude Include="..\..\inst\include\INIReader.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\csv_tracking_visitor.hpp">
+      <Filter>Header Files\visitors</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\inst\include\fluxpool.hpp">
+      <Filter>Header Files\data</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -206,9 +206,6 @@
       <Filter>Source Files\components</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\oh_component.cpp">
-      <Filter>Source Files\components</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\onelineocean_component.cpp">
       <Filter>Source Files\components</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\slr_component.cpp">
@@ -262,9 +259,6 @@
     <ClCompile Include="..\..\src\simpleNbox.cpp">
       <Filter>Source Files\models</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\csv_output_visitor.cpp">
-      <Filter>Source Files\visitors</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\csv_outputstream_visitor.cpp">
       <Filter>Source Files\visitors</Filter>
     </ClCompile>
@@ -273,6 +267,12 @@
     </ClCompile>
     <ClCompile Include="..\..\src\INIReader.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\csv_tracking_visitor.cpp">
+      <Filter>Source Files\visitors</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\simpleNbox-runtime.cpp">
+      <Filter>Source Files\models</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/project_files/VS/hector.vcxproj
+++ b/project_files/VS/hector.vcxproj
@@ -94,8 +94,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\..\libs\boost-lib;$(IncludePath)</IncludePath>
-    <LibraryPath>..\..\libs\boost-lib\stage\lib;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(BOOSTROOT);$(IncludePath)</IncludePath>
+    <LibraryPath>$(BOOSTLIB);$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/project_files/VS/hector.vcxproj
+++ b/project_files/VS/hector.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\source\main.cpp" />
+    <ClCompile Include="..\..\src\main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="hector-lib.vcxproj">
@@ -30,12 +30,13 @@
     <ProjectGuid>{1A212A99-F400-4BC1-A4A3-1767FA1843F1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hector</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -48,13 +49,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -105,7 +106,7 @@
       <SDLCheck>true</SDLCheck>
       <OmitDefaultLibName>false</OmitDefaultLibName>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -120,7 +121,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -139,7 +140,7 @@
       <SDLCheck>true</SDLCheck>
       <OmitDefaultLibName>false</OmitDefaultLibName>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,7 +159,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\headers;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\inst\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/project_files/VS/hector.vcxproj
+++ b/project_files/VS/hector.vcxproj
@@ -30,32 +30,32 @@
     <ProjectGuid>{1A212A99-F400-4BC1-A4A3-1767FA1843F1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>hector</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/vignettes/manual/BuildHector.Rmd
+++ b/vignettes/manual/BuildHector.Rmd
@@ -183,6 +183,16 @@ Xcode Resources
 * Open Hector in the visual studio code IDE, build Hector with Terminal --> Run Build Task or with a `make hector` call in VSC terminal window. 
 * Run --> Start Debugging or Run Without Debugging or with `./src/hector ./inst/input/name-of-ini.ini` in the VSC terminal window. 
 
-## Visual Studio
+## Visual Studio / Microsoft Visual C++
 
-VS is not supported at this time. See [VS Hector github issue](https://github.com/JGCRI/hector/issues/415) for more details. 
+* Install [Visual Studio](https://visualstudio.microsoft.com/vs/community/) and be sure to the Visual C++ add on as well.
+* Download and install [Boost](https://www.boost.org).  Note you will need to Build the `system` and `filesystem` libraries, details can be found [here](https://www.boost.org/doc/libs/1_75_0/more/getting_started/windows.html).
+* Set the environment variables:
+  * `BOOSTROOT` to the location to which you installed Boost (i.e. `C:\boost_1_75_0`)
+  * `BOOSTLIB` to the location within Boost where the compiled libraries exist (i.e. `C:\boost_1_75_0\stage\lib`)
+* Open the Visual Studio project file which is located in your hector repository under `project_files/VS/hector.sln`
+* Build the `hector` target
+* To run hector:
+  * From the CMD prompt: `project_files/VS/x64/Release/hector.exe ./inst/input/name-of-ini.ini`
+  * From with in the Visual Studio debugger (the working directory will default to `project_files/VS`): `x64/Release/hector.exe ../../inst/input/name-of-ini.ini`
+


### PR DESCRIPTION
Update the Visual Studio project file to ensure we can still build a standalone `hector.exe` and `libhector` on Windows.  This closes #415 

A couple of considerations outstanding:
* Where to put the compiled `hector.exe` (Right now it is just in the build folder: `./project_files/VS/x64/Release/hector.exe`)
* Where to look for boost.  I started by pulling the VS project from `gcam-integration` which was fairly up to date.  But that means it is looking for boost relative to where GCAM wants is (../../../../libs/boost-lib).  I don't think that is what we want for stand alone builds but I'm not sure what we _do_ want.

Possible additional tasks:
* Add a Github action to ensure hector standalone builds and runs on Windows
* Address the following deprecation warnings from boost:
```
Severity        Code    Description     Project File    Line    Suppression State
Message         This header is deprecated. Use <boost/range/iterator.hpp> instead.      hector-lib      C:\libs\boost-lib\boost\range\result_iterator.hpp       20
Message         This header is deprecated. Use <boost/range/reverse_iterator.hpp> instead.      hector-lib      C:\libs\boost-lib\boost\range\const_reverse_iterator.hpp        20
Message         This header is deprecated. Use <boost/range/reverse_iterator.hpp> instead.      hector-lib      C:\libs\boost-lib\boost\range\reverse_result_iterator.hpp       20
```
 