### PR TITLE
C++ 17 / std::filesystem

### DIFF
--- a/inst/include/tseries.hpp
+++ b/inst/include/tseries.hpp
@@ -250,21 +250,21 @@ struct interp_helper<string> {
     static void error_check( const std::map<double, T_unit_type>& userData,
                              h_interpolator& interpolator, std::string name,
                              bool& isDirty, bool endinterp_allowed,
-                             const double index ) throw( h_exception )
+                             const double index ) noexcept(false)
     {
         H_THROW( "String interpolation not allowed" );
     }
     static T_unit_type interp( const std::map<double, T_unit_type>& userData,
                                h_interpolator& interpolator, std::string name,
                                bool& isDirty, bool endinterp_allowed,
-                               const double index ) throw( h_exception )
+                               const double index ) noexcept(false)
     {
          H_THROW( "String interpolation not allowed" );
     }
     static T_unit_type calc_deriv( const std::map<double, T_unit_type>& userData,
                                    h_interpolator& interpolator, std::string name,
                                    bool& isDirty, bool endinterp_allowed,
-                                   const double index ) throw( h_exception )
+                                   const double index ) noexcept(false)
     {
         H_THROW( "String derivative not allowed" );
     }

--- a/src/ini_to_core_reader.cpp
+++ b/src/ini_to_core_reader.cpp
@@ -16,11 +16,16 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-// ANS: If using the R package, use Rcpp to call R's file processing
-// functions. Otherwise (e.g. if building standalone Hector), fall
-// back to boost::filesystem (which needs to be installed).
+// If using the R package, use Rcpp to call R's file processing
+// functions. Otherwise (e.g. if building standalone Hector),
+// use std::filesystem (which is available since the C++ 17 standard)
+// if available and finally fall back to boost::filesystem (which
+// needs to be installed).
 #ifdef USE_RCPP
 #include <Rcpp.h>
+#elif __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
 #else
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -17,14 +17,28 @@
 #include "h_util.hpp"
 #include <algorithm>
 
+
 // If using the R package, use Rcpp to call R's file processing
-// functions. Otherwise (e.g. if building standalone Hector), fall
-// back to boost::filesystem (which needs to be installed).
+// functions. Otherwise (e.g. if building standalone Hector),
+// use std::filesystem (which is available since the C++ 17 standard)
+// if available and finally fall back to boost::filesystem (which
+// needs to be installed).
+
+// Language feature detection (to use __cpp_lib_filesystem) isn't even
+// available unil the C++20 standard.  Luckily we can use boost to get
+// it in the meantime.
+#include <boost/config.hpp>
+
 #ifdef USE_RCPP
 #include <Rcpp.h>
+#elif __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+typedef std::error_code fs_error_code;
 #else
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
+typedef boost::system::error_code fs_error_code;
 #endif
 
 #ifdef USE_RCPP
@@ -294,7 +308,7 @@ void Logger::chk_logdir(std::string dir)
         // either does not exist or is a file
         // we can try to create it and if it still fails it must
         // have been a file or a permissions error
-        boost::system::error_code status;
+        fs_error_code status;
         if(!fs::create_directory(fs_dir, status)) {
             H_THROW("Directory "+dir+" does not exist and could not create it.");
         }

--- a/src/makefile.standalone
+++ b/src/makefile.standalone
@@ -7,13 +7,28 @@
 ifeq ($(strip $(CXX)),)
 	CXX  = g++
 endif 
-CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD -std=c++14 
+
+## Check if the user is willing to use the c++17 standard which
+## is mostly just so that we do not have to bother linking any
+## boost libraries
+ifeq ($(strip $(USE_CXX17)),)
+	## Not set so use the default standard: c++14 and set the linker flags
+	## to find and link boost system/filesystem which are then required
+	BOOST_LDFLAGS = -L"$(BOOSTLIB)" -Wl,-rpath,"$(BOOSTLIB)"
+	BOOST_LIB_IMPORT = -lboost_system -lboost_filesystem
+	CXXSTD = c++14
+else
+	## We can just set the standard and leave BOOST_LDFLAGS and BOOST_LIB_IMPORT
+	## alone
+	CXXSTD = c++17
+endif
+CXXFLAGS = -g $(INCLUDES) $(OPTFLAGS) $(CXXEXTRA) $(CXXPROF) $(WFLAGS) -MMD -std=$(CXXSTD)
 ## Note that $(CCEXTRA) allows for custom flags; see https://github.com/JGCRI/hector/issues/407
 CFLAGS   = -g $(INCLUDES) $(OPTFLAGS) $(CCEXTRA) -MMD
 INCLUDES = -I"$(BOOSTINC)" -I"$(HDRDIR)"
 WFLAGS   = -Wall -Wno-unused-local-typedefs # Turn off warnings, esp. one common in Boost files
 OPTFLAGS = -O3
-LDFLAGS	 = $(CXXPROF) -L"$(BOOSTLIB)" -L. -Wl,-rpath,"$(BOOSTLIB)"
+LDFLAGS	 = $(CXXPROF) -L. $(BOOST_LDFLAGS)
 HDRDIR	 = $(CURDIR)/../inst/include
 
 ## These will be needed by the testing makefile
@@ -74,7 +89,7 @@ OBJS	= $(CXXSRCS:.cpp=.o) $(CSRCS:.c=.o)
 ## ----------------------------------------------------
 ## Default target
 hector: libhector.a main.o
-	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lm -lboost_system -lboost_filesystem
+	$(CXX) $(LDFLAGS) -o hector main.o -lhector -lm $(BOOST_LIB_IMPORT)
 
 ## Testing target
 testing: libhector.a


### PR DESCRIPTION
@bpbond when I was looking around to update the VS project I found an old branch I made for Corrine to drop boost system/filesystem by using the C++ 17 standard.  I dusted that off and decided that I would make using C++ 17 optional and push that branch up.  Then we could decide what to do with it.  (Note I have just modified the `makefile.standalone` for the moment until we decide what to do).  This would close #151 

C++ compilers have had good support for C++ 17 / std::filesystem for a long time now.  With the exception of Apple which didn't include support in their version of the standard library until OS X Catalina 10.15.
Linking boost has come up with folks who want to run GCAM/hector on a compute cluster where the libraries (i.e. boost) is managed by the administrators and was built with an ancient version of GCC.  When I tell them they will need to compile boost themselves I am met with (the email equivalent) of a blank stare.  Having an option to use `std::filesystem` would at least give an easy out.

Given all of this I could see a few options:
* Just forget it and continue with linking boost
* Make it optional to use c++17/std::filesystem instead of c++14/boost::filesystem (it is not a huge lift as can be seen in this PR)
* Make c++17/std::filesystem the default (I would perhaps still leave the option to fall back to boost as again it isn't a huge lift and to cover any old Mac users).