### PR TITLE
Update manual and vignette

### DIFF
--- a/vignettes/intro-to-hector.Rmd
+++ b/vignettes/intro-to-hector.Rmd
@@ -24,6 +24,8 @@ This vignette provides a basic introduction for running Hector with R.
 First, it shows how to do a simple Hector run with one of Hector's built-in scenarios.
 Then, it shows how to modify Hector parameters from within R and uses this functionality to perform a simple sensitivity analysis of how the CO$_2$ fertilization parameter $\beta$ affects several Hector output variables.
 
+If you do not yet have Hector installed, please reference the manual's instructions for [building and running Hector](https://jgcri.github.io/hector/articles/manual/BuildHector.html).
+
 # Basic run
 
 First, load the `hector` package.
@@ -156,7 +158,7 @@ However, it is still possible to change the values of certain _drivers_ and _sta
 
 ***
 
-So, as a result of the `reset` command, the core's `Current Date` is now the model start date--1745.
+So, as a result of the `reset` command, the core's `Current Date` is now the model start date -- 1745.
 We can now perform another run with the new CO$_2$ fertilization value.
 
 ```{r  run-sim-2}

--- a/vignettes/manual/BuildHector.Rmd
+++ b/vignettes/manual/BuildHector.Rmd
@@ -6,7 +6,7 @@ There are lots of ways to use Hector: as a stand alone executable, through the U
 
 To install R, follow the [official instructions](https://cloud.r-project.org/) for your platform.
 
-To install the version associated with the current `master` git branch on GitHub, use the `devtools::install_github` function.
+To install the version associated with the current `master` git branch on GitHub, use the `remotes`::install_github` function.
 This will automatically install all of Hector's dependencies as well.
 (Note that because this requires compiling from source, you will need to have a C compiler installed and configured.
 
@@ -21,29 +21,28 @@ Remember to restart R (or Rstudio) and to verify that `make` can be found. Execu
 On **Mac OS** and **Linux**, the required tools should be included as part of a standard R installation.
 
 ```r
-# If the `devtools` isn't installed, first run:
-# install.packages("devtools")
-devtools::install_github("jgcri/hector")
+# If the `remotes` package isn't installed, first run:
+# install.packages("remotes")
+remotes::install_github("jgcri/hector")
 
 # You can also install from specific git tags...
-devtools::install_github("jgcri/hector@2.2.2")
+remotes::install_github("jgcri/hector@2.2.2")
 # ...branches...
-devtools::install_github("jgcri/hector@krd-perscribe_co2Con")
+remotes::install_github("jgcri/hector@krd-perscribe_co2Con")
 # ...or commit hashes.
-devtools::install_github("jgcri/hector@16c480a")
+remotes::install_github("jgcri/hector@16c480a")
 ```
 
 Finally, to install from a local copy of the source code, you can use the following code:
 
 ```r
-devtools::install("/path/to/hector")
+remotes::install("/path/to/hector")
 # For the current directory, use `"."` or run the function with no arguments.
 ```
 
 ...or, if you are using the [RStudio IDE](https://www.rstudio.com/products/rstudio/), use the "Install and Restart", "Clean and Rebuild", and similar tools in the "Build" tab.
 
-Although very common and broadly useful, the `devtools` package has many R package dependencies, including some with system dependencies.
-If you do not want to install `devtools`, you can also install from a local copy by using the base-R `install.packages` function as follows:
+If you do not want to install `remotes`, you can also install from a local copy by using the base-R `install.packages` function as follows:
 
 ```r
 install.packages("/path/to/hector", repos = NULL)


### PR DESCRIPTION
Changed manual's installation instructions to use `remotes` instead of `devtools` and updated "intro to Hector" vignette to reference the installation instructions before beginning.

Closes #540 
@bpbond 