### PR TITLE
Cleanup tracking data output

### DIFF
--- a/inst/include/avisitor.hpp
+++ b/inst/include/avisitor.hpp
@@ -58,6 +58,12 @@ public:
     virtual void reset( const double reset_date ) {}
 
     //------------------------------------------------------------------------------
+    /*! \brief Update the Tracking Data output if applicable.
+     *  \param tracking_out The Tracking Data output stream to place results into.
+     */
+    virtual void outputTrackingData( std::ostream& tracking_out ) const {}
+
+    //------------------------------------------------------------------------------
     // Add a visit for all visitable subclasses here.
     // TODO: should we create a .cpp for these?
     virtual void visit( Core* core ) {}

--- a/inst/include/csv_tracking_visitor.hpp
+++ b/inst/include/csv_tracking_visitor.hpp
@@ -27,7 +27,7 @@ namespace Hector {
  */
 class CSVFluxPoolVisitor : public AVisitor {
 public:
-    CSVFluxPoolVisitor( ostream& outputStream, const bool printHeader = true );
+    CSVFluxPoolVisitor( std::ostream& outputStream, const bool printHeader = true );
     ~CSVFluxPoolVisitor();
 
     virtual bool shouldVisit( const bool in_spinup, const double date );
@@ -35,8 +35,8 @@ public:
     virtual void visit( SimpleNbox* c );
     virtual void visit( OceanComponent* c );
 
-    std::string get_buffer() const;
     void reset( const double reset_date );
+    virtual void outputTrackingData( std::ostream& tracking_out ) const;
     
 private:
     //! The file output stream in which the csv output will be written to.

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -205,15 +205,12 @@ void Core::init() {
  */
 std::string Core::getTrackingData() const {
 
-    // I'm pretty sure I should be using a virtual function for this
+    // use a string output stream to collect the results
+    ostringstream tracking_out;
     for( auto visitorIt : modelVisitors ) {
-        const CSVFluxPoolVisitor* bad_idea = dynamic_cast<const CSVFluxPoolVisitor*>(visitorIt);
-        if(bad_idea != nullptr ) {
-            return(bad_idea->get_buffer());
-        }
-
+        visitorIt->outputTrackingData(tracking_out);
     }
-    return "";
+    return tracking_out.str();
 }
 
 //------------------------------------------------------------------------------

--- a/src/csv_tracking_visitor.cpp
+++ b/src/csv_tracking_visitor.cpp
@@ -132,20 +132,16 @@ void CSVFluxPoolVisitor::visit( OceanComponent* c ) {
 }
 
 //------------------------------------------------------------------------------
-/*! \brief Assemble the time series strings into a single string and return to core.
- *  \return The visitor output assembled into a single string.
- */
-std::string CSVFluxPoolVisitor::get_buffer() const {
-    stringstream output;
-    
+/*! \brief Assemble the time series strings into the given tracking output stream.
+ *  \param tracking_out The output stream to write results into.
+ */ 
+void CSVFluxPoolVisitor::outputTrackingData( ostream& tracking_out ) const {
     if(csvBuffer.size()) {
-        output << header; // the header (or an empty string)        
+        tracking_out << header; // the header (or an empty string)        
         for( double yr = csvBuffer.firstdate(); yr <= csvBuffer.lastdate(); yr++ ) {
-            output << csvBuffer.get(yr);
+            tracking_out << csvBuffer.get(yr);
         }
     }
-    
-    return output.str();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Cleanup collecting tracking data output by adding an `outputTrackingData` method to `AVistor` which only `CSVTrackingVisitor` will implement.  Never the less it is a cleaner solution than having to dynamic_cast.  This closes #483