### PR TITLE
Clean up R CMD MAKE warnings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,7 +3,7 @@
 ^hector.Rproj$
 ^\.Rproj\.user$
 
-## Github config, license, CI, etc.
+## GitHub config, license, CI, etc.
 ^CONTRIBUTING.md$
 ^LICENSE.md$
 ^changelog.txt$
@@ -25,12 +25,12 @@
 ^src/.*\.txt$
 ^src/.*\.a$
 ^src/.*\.d$
+^.*\.o$
 ^src/main.*$
 ^src/makefile.standalone$
 ^src/testing$
 ^misc$
 ^data-raw$
-^analysis$
 ^.vscode$
 
 # pkgdown config and output

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,6 +58,6 @@ Collate:
     'units.R'
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2
-SystemRequirements: GNUmake
+SystemRequirements: GNU make
 URL: https://github.com/JGCRI/hector
 BugReports: https://github.com/JGCRI/hector/issues

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1340,18 +1340,21 @@ F_LUCD <- function() {
 }
 
 #' @describeIn carboncycle Vegetation C pool (`"Pg C"`)
+#' @param biome Name of biome (leave empty for global)
 #' @export
 VEG_C <- function(biome = "") {
     .Call('_hector_VEG_C', PACKAGE = 'hector', biome)
 }
 
 #' @describeIn carboncycle Vegetation detritus C pool (`"Pg C"`)
+#' @param biome Name of biome (leave empty for global)
 #' @export
 DETRITUS_C <- function(biome = "") {
     .Call('_hector_DETRITUS_C', PACKAGE = 'hector', biome)
 }
 
 #' @describeIn carboncycle Soil C pool (`"Pg C"`)
+#' @param biome Name of biome (leave empty for global)
 #' @export
 SOIL_C <- function(biome = "") {
     .Call('_hector_SOIL_C', PACKAGE = 'hector', biome)
@@ -1365,6 +1368,7 @@ EARTH_C <- function() {
 
 #' @describeIn carboncycle Initial net primary productivity (NPP)
 #'   flux (`"Pg C year^-1"`)
+#' @param biome Name of biome (leave empty for global)
 #' @export
 NPP_FLUX0 <- function(biome = "") {
     .Call('_hector_NPP_FLUX0', PACKAGE = 'hector', biome)

--- a/man/carboncycle.Rd
+++ b/man/carboncycle.Rd
@@ -49,6 +49,9 @@ EARTH_C()
 
 NPP_FLUX0(biome = "")
 }
+\arguments{
+\item{biome}{Name of biome (leave empty for global)}
+}
 \description{
 These identifiers correspond to variables that can be read and/or set in the
 carbon cycle

--- a/src/rcpp_constants.cpp
+++ b/src/rcpp_constants.cpp
@@ -1655,6 +1655,7 @@ return D_F_LUCD;
 }
 
 //' @describeIn carboncycle Vegetation C pool (`"Pg C"`)
+//' @param biome Name of biome (leave empty for global)
 //' @export
 // [[Rcpp::export]]
 String VEG_C(String biome = "") {
@@ -1666,6 +1667,7 @@ String VEG_C(String biome = "") {
 }
 
 //' @describeIn carboncycle Vegetation detritus C pool (`"Pg C"`)
+//' @param biome Name of biome (leave empty for global)
 //' @export
 // [[Rcpp::export]]
 String DETRITUS_C(String biome = "") {
@@ -1677,6 +1679,7 @@ String DETRITUS_C(String biome = "") {
 }
 
 //' @describeIn carboncycle Soil C pool (`"Pg C"`)
+//' @param biome Name of biome (leave empty for global)
 //' @export
 // [[Rcpp::export]]
 String SOIL_C(String biome = "") {
@@ -1696,6 +1699,7 @@ String EARTH_C() {
 
 //' @describeIn carboncycle Initial net primary productivity (NPP)
 //'   flux (`"Pg C year^-1"`)
+//' @param biome Name of biome (leave empty for global)
 //' @export
 // [[Rcpp::export]]
 String NPP_FLUX0(String biome = "") {


### PR DESCRIPTION
Removes warnings about:

* `.o` files in `inst/`
* Undocumented parameter in `carboncycle` object
* Non-portable Makefile ( #492 )

We are now at
```
0 errors ✓ | 0 warnings ✓ | 4 notes x

R CMD check succeeded
```

Closes #492 
