### PR TITLE
Replace custom code to echo to screen with boost.iostreams

### DIFF
--- a/inst/include/logger.hpp
+++ b/inst/include/logger.hpp
@@ -15,7 +15,7 @@
  */
 
 #include <iostream>
-#include <fstream>
+#include <boost/iostreams/filtering_stream.hpp>
 
 #include "h_exception.hpp"
 
@@ -62,38 +62,13 @@ private:
     bool enabled;
 
     //! The actual output stream which will handle the logging.
-    std::ostream loggerStream;
+    boost::iostreams::filtering_ostream loggerStream;
 
     static const std::string& logLevelToStr( const LogLevel logLevel );
 
     static const char* getDateTimeStamp();
 
-    static void chk_logdir(std::string dir);
-
     void printLogHeader( const LogLevel logLevel );
-
-    /*! \brief A customized file stream buffer to enable echoing to a console.
-     *
-     *  This subclass will override the virtual protected methods necessary for
-     *  output only.
-     */
-    class LoggerStreamBuf : public std::filebuf {
-    private:
-        //! A pointer to the streambuf of the console output stream, or null
-        //! if echoToScreen was set to false during construction.
-        std::streambuf* consoleBuf;
-    public:
-        LoggerStreamBuf( const bool echoToScreen );
-        virtual ~LoggerStreamBuf();
-
-    protected:
-        // std::streambuf methods
-        virtual int sync();
-
-        virtual int overflow( int c = EOF );
-
-        virtual std::streamsize xsputn( const char* s, std::streamsize n );
-    };
 
 public:
     Logger();

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -12,6 +12,7 @@
  *
  */
 
+#include <fstream>
 #include "boost/algorithm/string.hpp"
 
 #include "imodel_component.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <iostream>
+#include <fstream>
 
 #include "core.hpp"
 #include "logger.hpp"

--- a/src/unit-testing/test_logger.cpp
+++ b/src/unit-testing/test_logger.cpp
@@ -32,17 +32,21 @@ protected:
         // avoid stomping over someone else's files.
         H_ASSERT( !fileExists( testFile1.c_str() ), "testfile1 exists" );
         H_ASSERT( !fileExists( testFile2.c_str() ), "testfile2 exists" );
+
+        // swap out the cout buffer with a string stream so we can keep
+        // track of if messages get echoed when they should / should not
+        // be sure to keep a copy of the original so that we can restore
+        // it in TearDown
+        origCoutBuf = std::cout.rdbuf( &consoleTestBuff );
         
         loggerNoEcho.open( testFile1, false, true, Logger::WARNING );
-        std::streambuf* tmpBuff = std::cout.rdbuf( &consoleTestBuff );
         loggerEcho.open( testFile2, true, true, Logger::WARNING );
-        
-        // now that the logger has attached to our test buffer put the
-        // original back into cout
-        std::cout.rdbuf( tmpBuff );
     }
     
     virtual void TearDown() {
+        // restore the original cout buffer
+        std::cout.rdbuf( origCoutBuf );
+
         // close the loggers explicitly so that the temp files can be deleted.
         loggerNoEcho.close();
         loggerEcho.close();
@@ -75,6 +79,7 @@ protected:
     Logger loggerEcho;
     
     std::stringbuf consoleTestBuff;
+    std::streambuf* origCoutBuf;
 };
 
 TEST_F(LoggerTest, UninitializedLog) {

--- a/src/unit-testing/test_logger.cpp
+++ b/src/unit-testing/test_logger.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <iostream>
+#include <fstream>
 #include <sstream>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Replace the custom std::streambuffer in Logger (which was used to provide the ability to echo logging output to both screen and file) with boost::iostreams