### PR TITLE
Fix memory leak and use of uninitialized variable

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -111,9 +111,6 @@ void Core::init() {
     temp = new N2OComponent();
     modelComponents[ temp->getComponentName() ] = temp;
 
-    temp = new OzoneComponent();
-    modelComponents[ temp->getComponentName() ] = temp;
-
     temp = new ForcingComponent();
     modelComponents[ temp->getComponentName() ] = temp;
     temp = new slrComponent();

--- a/src/ocean_component.cpp
+++ b/src/ocean_component.cpp
@@ -248,7 +248,6 @@ void OceanComponent::prepareToRun() {
     const double I_preind_C = I_vol_frac * preind_C_ID;
     const double D_preind_C = D_vol_frac * preind_C_ID;
 
-
     // Set up our ocean box model.
     H_LOG( logger, Logger::DEBUG ) << "Setting up ocean box model" << std::endl;
     surfaceHL.initbox( HL_preind_C, "HL" );
@@ -278,7 +277,7 @@ void OceanComponent::prepareToRun() {
     double DO_IOex = ( tid.value( U_M3_S) * spy ) / D_volume;
     double IO_DOex = ( tid.value( U_M3_S) * spy ) / I_volume;
 
-    // make_connection( box to connect to, k value, window size (0=present only) )
+    // Make_connection( box to connect to, k value, window size (0=present only) )
     surfaceLL.make_connection( &surfaceHL, LL_HL, 1 );
     surfaceLL.make_connection( &inter, LL_IOex, 1 );
     surfaceHL.make_connection( &deep, HL_DO, 1 );
@@ -287,7 +286,7 @@ void OceanComponent::prepareToRun() {
     inter.make_connection( &deep, IO_DOex, 1 );
     deep.make_connection( &inter, DO_IO + DO_IOex, 1 );
 
-    //inputs for surface chemistry boxes
+    // Inputs for surface chemistry boxes
     surfaceHL.deltaT.set( -16.4, U_DEGC );  // delta T to the absolute mean ocean tos to return the initial temperature value of the HL surface. See hector_cmip6data for details.
     surfaceHL.mychemistry.S             = 34.5; // Salinity Riley and Tongudai (1967)
     surfaceHL.mychemistry.volumeofbox   = HL_volume; // m3
@@ -305,7 +304,6 @@ void OceanComponent::prepareToRun() {
     surfaceHL.log_state();
     inter.log_state();
     deep.log_state();
-
 }
 
 //------------------------------------------------------------------------------

--- a/src/ocean_component.cpp
+++ b/src/ocean_component.cpp
@@ -206,7 +206,7 @@ void OceanComponent::prepareToRun() {
     H_LOG( logger, Logger::DEBUG ) << "prepareToRun " << std::endl;
 
     // Define constants used in ocean box set up.
-    double spy = 60 * 60 * 24 * 365.25;  // seconds per year
+    const double spy = 60 * 60 * 24 * 365.25;  // seconds per year
 
     // ocean depth
     double thick_LL = 100;         // (m) Thickness of surface ocean from Knox and McElroy (1984)
@@ -357,8 +357,6 @@ void OceanComponent::run( const double runToDate ) {
 
     Ca = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2 );
     SST.set(core->sendMessage( M_GETDATA, D_OCEAN_SURFACE_TEMP ), U_DEGC);
-
-
 
     in_spinup = core->inSpinup();
 

--- a/src/ocean_csys.cpp
+++ b/src/ocean_csys.cpp
@@ -354,7 +354,7 @@ unitval oceancsys::calc_annual_surface_flux( const unitval& Ca, const double cpo
  * Uses carbon pool, mass of carbon, density of seawater and volume of the box
  */
 unitval oceancsys::convertToDIC( const unitval carbon ) {
-    // Carbon pool / (C atmoic mass * density of sea water * volume )
+    // Carbon pool / (C atomic mass * density of sea water * volume )
 	const double dic = ( ( carbon.value( U_PGC ) * 1e15 ) * ( 1.0/12.01 ) * (1.0/1027.0 ) * ( 1.0/volumeofbox ) ); // mol/kg
 	return unitval( dic * 1e6, U_UMOL_KG );
 }

--- a/src/oceanbox.cpp
+++ b/src/oceanbox.cpp
@@ -276,12 +276,15 @@ void oceanbox::new_year( const unitval SST ) {
     for( unsigned i=0; i < connection_window.size(); i++ ){
         annual_box_fluxes[ connection_list[ i ] ] = unitval( 0.0, U_PGC_YR );
     }
-    atmosphere_flux.set( 0.0, U_PGC );
     Tbox = compute_tabsC( SST );
 
     // save for Revelle Calc
     pco2_lastyear = Ca;
-    dic_lastyear = mychemistry.convertToDIC( carbon );
+
+    if( surfacebox ) {
+        atmosphere_flux.set( 0.0, U_PGC );
+        dic_lastyear = mychemistry.convertToDIC( carbon );
+    }
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes two problems identified by @pralitp in #582 
* We had two `new OzoneComponent()` calls in `core.cpp`; one has been removed
* `ocean_csys::convertToDIC` was using an uninitialized variable as it was being called for the intermediate and deep boxes, which don't have active chemistry (and thus their `volumeOfBox` was never set). This has been changed
* Also a couple of minor tweaks elsewhere

There is no performance change:

![comp](https://user-images.githubusercontent.com/1956468/158534613-c20819c5-fe40-4823-acf2-fc99e265804c.png)

Closes #582