### PR TITLE
Install libcurl

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -40,6 +40,9 @@ jobs:
           key: macOS-r-4.0-2-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: macOS-r-4.0-2-
 
+      - name: Install libcurl
+        run: sudo apt-get install libcurl4-openssl-dev
+
       - name: Install dependencies
         run: |
           install.packages(c("remotes"))


### PR DESCRIPTION
The `test-coverage` check is failing in land-tracking, because covr needs curl which needs libcurl. Bringing over the step we have in `leeyabot`.