### PR TITLE
Require dates for more model variables

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -41,6 +41,9 @@ fetchvars <- function(core, dates, vars = NULL, scenario = NULL) {
         f()
       })
     )
+    if (anyNA(dates)) {
+        stop("The default vars (", paste(vars, collapse = ", "), ") all require dates")
+    }
   }
 
   if (is.null(scenario)) {

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -165,7 +165,7 @@ void CSVOutputStreamVisitor::visit( SimpleNbox* c ) {
     STREAM_MESSAGE( csvFile, c, D_NBP );
     STREAM_UNITVAL( csvFile, c, D_NPP, c->final_npp[ SNBOX_DEFAULT_BIOME ] );
     STREAM_UNITVAL( csvFile, c, D_RH, c->final_rh[ SNBOX_DEFAULT_BIOME ] );
-    STREAM_MESSAGE( csvFile, c, D_ATMOSPHERIC_CO2 );
+    STREAM_MESSAGE_DATE( csvFile, c, D_ATMOSPHERIC_CO2, current_date );
     STREAM_MESSAGE( csvFile, c, D_ATMOSPHERIC_C );
     STREAM_MESSAGE( csvFile, c, D_ATMOSPHERIC_C_RESIDUAL );
     STREAM_MESSAGE( csvFile, c, D_VEGC );

--- a/src/ocean_component.cpp
+++ b/src/ocean_component.cpp
@@ -353,7 +353,7 @@ void OceanComponent::run( const double runToDate ) {
         deep.start_tracking();
     }
 
-    Ca = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2 );
+    Ca = core->sendMessage( M_GETDATA, D_ATMOSPHERIC_CO2, message_data( runToDate ) );
     SST.set(core->sendMessage( M_GETDATA, D_OCEAN_SURFACE_TEMP ), U_DEGC);
 
     in_spinup = core->inSpinup();

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -117,8 +117,9 @@ void SimpleNbox::prepareToRun()
     }
 
     // Set atmospheric C based on the requested preindustrial [CO2]
-    atmos_c.set(C0.value(U_PPMV_CO2) * PPMVCO2_TO_PGC, U_PGC, atmos_c.tracking, atmos_c.name);
-
+    atmos_c.set( C0.value( U_PPMV_CO2 ) * PPMVCO2_TO_PGC, U_PGC, atmos_c.tracking, atmos_c.name );
+    atmos_c_ts.set( core->getStartDate(), atmos_c );
+    
     // Constraint logging
     if( CO2_constrain.size() ) {
         Logger& glog = core->getGlobalLogger();

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -50,7 +50,9 @@ SimpleNbox::SimpleNbox() : CarbonCycleModel( 6 ), masstot(0.0) {
     
     // The actual atmos_c value will be filled in later by setData
     atmos_c.set(0.0, U_PGC, false, "atmos_c");
-
+    atmos_c_ts.allowInterp( true );
+    atmos_c_ts.name = "atmos_c_ts";
+    
     // earth_c keeps track of how much fossil C is pulled out
     // so that we can do a mass-balance check throughout the run
     // 2020-02-05 With the introduction of non-negative 'fluxpool' class
@@ -440,6 +442,7 @@ unitval SimpleNbox::getData(const std::string& varName,
         else
             returnval = atmos_c_ts.get(date);
     } else if( varNameParsed == D_ATMOSPHERIC_CO2 ) {
+        H_ASSERT( date != Core::undefinedIndex(), "Date required for atmospheric CO2" );
         returnval = Ca( date );
     } else if( varNameParsed == D_ATMOSPHERIC_C_RESIDUAL ) {
         if(date == Core::undefinedIndex())

--- a/src/temperature_component.cpp
+++ b/src/temperature_component.cpp
@@ -368,7 +368,6 @@ void TemperatureComponent::run( const double runToDate ) {
     //// will rise in parallel with the value reported by ForcingComponent.
 
     // If we never had any temperature constraint, `internal_Ftot` will match `Ftot`.
-    //
 
     // Some needed inputs
     int tstep = runToDate - core->getStartDate();
@@ -376,16 +375,16 @@ void TemperatureComponent::run( const double runToDate ) {
     // Calculate the total aresol forcing from aerosol-radiation interactions and the
     // aerosol-cloud interactions so that that total aerosol forcing can be adjusted
     // by the aerosol forcing scaling factor.
-    double aero_forcing = core->sendMessage( M_GETDATA, D_RF_BC ).value( U_W_M2 ) +
-    core->sendMessage( M_GETDATA, D_RF_OC).value( U_W_M2 ) +
-    core->sendMessage( M_GETDATA, D_RF_NH3).value( U_W_M2 ) +
-    core->sendMessage( M_GETDATA, D_RF_SO2).value( U_W_M2 ) +
-    core->sendMessage( M_GETDATA, D_RF_ACI).value( U_W_M2 ) ;
+    double aero_forcing = core->sendMessage( M_GETDATA, D_RF_BC, message_data( runToDate )).value( U_W_M2 ) +
+    core->sendMessage( M_GETDATA, D_RF_OC, message_data( runToDate )).value( U_W_M2 ) +
+    core->sendMessage( M_GETDATA, D_RF_NH3, message_data( runToDate )).value( U_W_M2 ) +
+    core->sendMessage( M_GETDATA, D_RF_SO2, message_data( runToDate )).value( U_W_M2 ) +
+    core->sendMessage( M_GETDATA, D_RF_ACI, message_data( runToDate )).value( U_W_M2 ) ;
 
-    double volcanic_forcing = double(core->sendMessage(M_GETDATA, D_RF_VOL));
+    double volcanic_forcing = double(core->sendMessage( M_GETDATA, D_RF_VOL, message_data( runToDate )));
 
     // Adjust total forcing to account for the aerosol and volcanic forcing scaling factor
-    forcing[tstep] = double(core->sendMessage(M_GETDATA, D_RF_TOTAL).value(U_W_M2))
+    forcing[tstep] = double(core->sendMessage(M_GETDATA, D_RF_TOTAL, message_data( runToDate)).value(U_W_M2))
     - (1.0 - alpha) * aero_forcing
     - (1.0 - volscl) * volcanic_forcing;
 

--- a/tests/testthat/test_messages.R
+++ b/tests/testthat/test_messages.R
@@ -10,5 +10,12 @@ test_that("Invalid input variable returns error", {
     expect_error(setvar(core, NA, "global.permafrost.beta", 10, ""),
                  regexp = "Invalid input variable: '")
     shutdown(core)
+})
 
+test_that("Default fetchvar without dates returns error", {
+
+    # Test that fetchvars errors if neither dates nor vars is supplied
+    core <- newcore(inifile)
+    expect_error(fetchvars(core, NA), regexp = "all require dates")
+    shutdown(core)
 })

--- a/tests/testthat/test_wrapper.R
+++ b/tests/testthat/test_wrapper.R
@@ -68,11 +68,11 @@ test_that("Write out logs", {
   # Check that errors on shutdown cores get caught
   expect_error(getdate(hc_log), "Invalid or inactive")
   expect_error(run(hc_log), "Invalid or inactive")
-  expect_error(fetchvars(hc_log), "Invalid or inactive")
+  expect_error(fetchvars(hc_log, hc_log$strtdate), "Invalid or inactive")
 })
 
 
-## Make sure that that when the Hector core is shut downsys
+## Make sure that that when the Hector core is shut down
 ## everything is tidied up.
 test_that("Garbage collection shuts down hector cores", {
   ## This test makes use of some knowledge about the structure of the hector


### PR DESCRIPTION
#591 documents that, if you call `fetchvars(hc, dates = NA)` you get back the end-of run Ftot, Ca, FCO2, and Tgav data with "NA" for year.

Fixing this was slightly tricky. Previously, all these variables could be queried from their respective model components _without_ supplying a date, and the current value internal value would be returned. This was handy but opened the door to the R user querying without a date as well. Fixing this required:
* Change Ca to require a date, which means supplying the date in the two internal queries for it: in `csvOutputStreamVisitor` (straightforward) and `OceanComponent` (less so). We now ensure that the parameter C0 is written to the `atmos_c_ts` variable, and that it's allowed to interpolate, so that the ocean can get values correctly.
* Change all forcing variables to require a date. This involved reworking `forcingComponent::getData`, which was a mess.
* `fetchvars(hc, NA)` now returns an error, and it was potentially unclear, so I added a special check for this.

Closes #591 