### PR TITLE
Silence boost-related clang warnings

### DIFF
--- a/inst/include/logger.hpp
+++ b/inst/include/logger.hpp
@@ -15,7 +15,10 @@
  */
 
 #include <iostream>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <boost/iostreams/filtering_stream.hpp>
+#pragma clang diagnostic pop
 
 #include "h_exception.hpp"
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -13,7 +13,10 @@
  */
 
 #include <fstream>
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include "boost/algorithm/string.hpp"
+#pragma clang diagnostic pop
 
 #include "imodel_component.hpp"
 #include "halocarbon_component.hpp"

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -15,7 +15,10 @@
  *
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include "boost/algorithm/string.hpp"
+#pragma clang diagnostic pop
 
 #include "dependency_finder.hpp"
 #include "simpleNbox.hpp"

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -12,7 +12,10 @@
  *
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include "boost/algorithm/string.hpp"
+#pragma clang diagnostic pop
 
 #include "dependency_finder.hpp"
 #include "simpleNbox.hpp"


### PR DESCRIPTION
Boost's `formatter.hpp` has a documentation error that generates clang warnings when building Hector:

<img width="923" alt="Screen Shot 2022-06-18 at 2 30 25 PM" src="https://user-images.githubusercontent.com/1956468/174451835-dbc23f69-b001-430e-8d67-78f36781ad93.png">

These warnings are a PITA and make it hard to find Hector-related issues.

This PR surrounds several Boost includes with clang pragmas, silencing the warnings.
