### PR TITLE
Update workflows to use r-lib v2 branch

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/leeyabot.yml
+++ b/.github/workflows/leeyabot.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: iterative/setup-cml@v1
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: 'release'
 

--- a/.github/workflows/rcmd.yml
+++ b/.github/workflows/rcmd.yml
@@ -47,11 +47,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
Our GitHub Actions R workflows make use of [r-lib](https://github.com/r-lib/actions#github-actions-for-the-r-language) where recent changes have broken any references to its `master` branch. 

This PR follow advice [here](https://github.com/r-lib/actions/issues/639) and changes these references to `v2`, hopefully fixing our tests.
