### PR TITLE
Update StyleGuide to note that clang-format shouldn't touch rcpp_constants

### DIFF
--- a/vignettes/articles/StyleGuide.Rmd
+++ b/vignettes/articles/StyleGuide.Rmd
@@ -17,7 +17,8 @@ For example, assuming that the working directory is the repository root:
 # First, if needed:
 brew install clang-format
 
-clang-format -i src/*.c*
+# Important note: we do NOT want to touch `src/rcpp_constants.cpp`
+find src/ -name "*.c*" | grep -v rcpp_constants | clang-format -i
 clang-format -i inst/include/*.h*
 ```
 


### PR DESCRIPTION
Because doing so can cause bad things to happen to the roxygen2 documentation step.

Per discussion today with @kdorheim 

Closes #649 
