### PR TITLE
Bring test_dependency_finder.cpp up to date and re-enable it

### DIFF
--- a/project_files/Xcode/hector.xcodeproj/project.pbxproj
+++ b/project_files/Xcode/hector.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		27B2C270261511C8005DE26D /* spline_forsythe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C24D261511C8005DE26D /* spline_forsythe.cpp */; };
 		27B2C271261511C8005DE26D /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27B2C24E261511C8005DE26D /* main.cpp */; };
 		27F2613726B55617004BDD47 /* csv_tracking_visitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 27962904268F237200333AA3 /* csv_tracking_visitor.cpp */; };
+		354045FC2913D50A00CA297D /* test_dependency_finder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 273FC38F26A3570B00D5303E /* test_dependency_finder.cpp */; };
 		35ACB833285E4F4E0025928F /* h_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 275CBFF127AC7CC0009E2AF5 /* h_util.cpp */; };
 		954D62AE278E005500840656 /* nh3_component.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 954D62AD278E005500840656 /* nh3_component.cpp */; };
 		954D62AF278E005500840656 /* nh3_component.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 954D62AD278E005500840656 /* nh3_component.cpp */; };
@@ -539,6 +540,7 @@
 				27A02A782615CBB800AF9BFA /* o3_component.cpp in Sources */,
 				27A02A792615CBB800AF9BFA /* n2o_component.cpp in Sources */,
 				27A02A7A2615CBB800AF9BFA /* h_reader.cpp in Sources */,
+				354045FC2913D50A00CA297D /* test_dependency_finder.cpp in Sources */,
 				273FC3A026A3570B00D5303E /* test_logger.cpp in Sources */,
 				273FC39726A3570B00D5303E /* testing_main.cpp in Sources */,
 				954D62AF278E005500840656 /* nh3_component.cpp in Sources */,

--- a/src/unit-testing/Makefile
+++ b/src/unit-testing/Makefile
@@ -5,7 +5,7 @@ SRCS	= $(wildcard *.cpp)
 
 ## ** TEMPORARY **
 ## the following files aren't working yet; remove them
-UNDONE = test_core.cpp test_csv_file_reader.cpp test_dependency_finder.cpp
+UNDONE = test_core.cpp test_csv_file_reader.cpp
 SRCS := $(filter-out $(UNDONE), $(SRCS))
 
 OBJS	= $(SRCS:.cpp=.o)

--- a/src/unit-testing/test_dependency_finder.cpp
+++ b/src/unit-testing/test_dependency_finder.cpp
@@ -105,9 +105,9 @@ TEST_F(TestDependencyFinder, TwoSeperate) {
     EXPECT_NE( dIt, ordering.end() );
 
     // expect that b is before a
-    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() );
+    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // expect that d is before c
-    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() );
+    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // can't say anything about the other relationships
 }
 
@@ -145,11 +145,11 @@ TEST_F(TestDependencyFinder, MultipleDependencies) {
     // expect that b is before a
     EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // expect that c is before a
-    EXPECT_LT( cIt - ordering.begin(), aIt - ordering.begin() );
+    EXPECT_LT( cIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // expect that d is before b
-    EXPECT_LT( dIt - ordering.begin(), bIt - ordering.begin() );
+    EXPECT_LT( dIt - ordering.begin(), bIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // expect that d is before c
-    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() );
+    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() ) << "Ordering: " << ordering << endl;
 }
 
 ostream& operator<<( ostream& out, const vector<string>& vec ) {

--- a/src/unit-testing/test_dependency_finder.cpp
+++ b/src/unit-testing/test_dependency_finder.cpp
@@ -105,10 +105,9 @@ TEST_F(TestDependencyFinder, TwoSeperate) {
     EXPECT_NE( dIt, ordering.end() );
 
     // expect that b is before a
-    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
+    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() );
     // expect that d is before c
-    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() ) << "Ordering: " << ordering << endl;
-    
+    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() );
     // can't say anything about the other relationships
 }
 
@@ -144,13 +143,13 @@ TEST_F(TestDependencyFinder, MultipleDependencies) {
     EXPECT_NE( dIt, ordering.end() );
     
     // expect that b is before a
-    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
+    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() );
     // expect that c is before a
-    EXPECT_LT( cIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
+    EXPECT_LT( cIt - ordering.begin(), aIt - ordering.begin() );
     // expect that d is before b
-    EXPECT_LT( dIt - ordering.begin(), bIt - ordering.begin() ) << "Ordering: " << ordering << endl;
+    EXPECT_LT( dIt - ordering.begin(), bIt - ordering.begin() );
     // expect that d is before c
-    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() ) << "Ordering: " << ordering << endl;
+    EXPECT_LT( dIt - ordering.begin(), cIt - ordering.begin() );
 }
 
 ostream& operator<<( ostream& out, const vector<string>& vec ) {

--- a/src/unit-testing/test_dependency_finder.cpp
+++ b/src/unit-testing/test_dependency_finder.cpp
@@ -143,7 +143,7 @@ TEST_F(TestDependencyFinder, MultipleDependencies) {
     EXPECT_NE( dIt, ordering.end() );
     
     // expect that b is before a
-    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() );
+    EXPECT_LT( bIt - ordering.begin(), aIt - ordering.begin() ) << "Ordering: " << ordering << endl;
     // expect that c is before a
     EXPECT_LT( cIt - ordering.begin(), aIt - ordering.begin() );
     // expect that d is before b

--- a/vignettes/articles/BuildHector.Rmd
+++ b/vignettes/articles/BuildHector.Rmd
@@ -160,11 +160,11 @@ Run Hector from the terminal:
 ./src/hector ./inst/input/name-of-ini.ini
 ```
 
-To run build and run the Hector unit tests, type `make testing`
+To build and run the Hector unit tests, type `make testing`
 and then
 
 ```
-./src/Testing/hector-unit-tests
+./src/unit-testing/hector-unit-tests
 ```
 
 ## Xcode (Mac OS X)


### PR DESCRIPTION
See #450 

@pralitp Re-enabling this Hector test file was triggering the following error from inside the googletest framework itself:

<img width="1107" alt="Screen Shot 2022-11-03 at 7 02 25 AM" src="https://user-images.githubusercontent.com/1956468/199705642-6ce8ab7a-a806-4c03-88c2-3e7ff65aecba.png">

...that stemmed from lines in `test_dependency_finder.cpp` like this:

<img width="747" alt="Screen Shot 2022-11-03 at 7 07 53 AM" src="https://user-images.githubusercontent.com/1956468/199705839-bf509493-30ae-4571-9f7e-861e76c5188e.png">

As you can see from the diff, I removed the ` << "Ordering: " << ordering << endl` end of the lines, after which things build and tests run fine. But I don't quite understand why.  Any insight? Are these lines now giving false positives, or was this something cosmetic that was fine to remove? Thanks.