### PR TITLE
Fix if else statement in RF CO2 that causes errors

### DIFF
--- a/src/forcing_component.cpp
+++ b/src/forcing_component.cpp
@@ -334,7 +334,7 @@ void ForcingComponent::run(const double runToDate) {
         alpha_prime = d1 - (pow(b1, 2) / (4 * a1));
       } else if (C0 < CO2_conc && CO2_conc < C_alpha_max) {
         alpha_prime = d1 + a1 * pow((CO2_conc - C0), 2) + b1 * (CO2_conc - C0);
-      } else if (CO2_conc < C0) {
+      } else if (CO2_conc <= C0) {
         alpha_prime = d1;
       } else {
         H_THROW("Caller is requesting unknown condition for CO2 SARF ");


### PR DESCRIPTION
Bug change - there should be no change in Hector outputs 

An if-else statement in the forcing_componet is throwing an error when [CO2] is held constant at pre-industrial values which causes major problems when trying to run idealized runs (abrupt steps, pi control, 1pct etc). 

This change prevents that error. 

```
# Set up a Hector core
ini_file <- here::here("inst", "input", "hector_ssp245.ini")
hc <- newcore(ini_file)

# Fetch the pre-industrial value
prei_co2 <- fetchvars(hc, dates = NA, vars = PREINDUSTRIAL_CO2())

# Read in constant [CO2]
df <- data.frame(year = 1745:2100,
                 value = prei_co2$value)
setvar(hc, dates = df$year, values = df$value, var = CO2_CONSTRAIN(), unit = getunits(CO2_CONSTRAIN()))
reset(hc)
run(hc)
```
Throws the following error 

```
The script returns the following error
> run(hc)
Error in run(hc) :
    Error while running hector:  msg:  	Caller is requesting unknown condition for CO2 SARF
func: 	run
file: 	forcing_component.cpp
ffile:	forcing_component.cpp

line: 	340
Called from: run(hc)
```

[co2_rf_bug.txt](https://github.com/JGCRI/hector/files/10043795/co2_rf_bug.txt)
R script ^^




