### PR TITLE
Shunt NBP constraint residual to ocean, not changing atmosphere

### DIFF
--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -292,7 +292,13 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
     newdet = newdet + pool_diff * c[SNBOX_DET] / total_land;
     newveg = newveg + pool_diff * c[SNBOX_VEG] / total_land;
     newsoil = newsoil + pool_diff * c[SNBOX_SOIL] / total_land;
-    newatmos = newatmos - pool_diff;
+    // We do NOT adjust the `newatmos` variable, because doing so can put the
+    // model into an atmos_C feedback; see https://github.com/JGCRI/hector/issues/659
+    // Instead, follow the CO2 constraint behavior and transfer any
+    // difference to the deep ocean
+    H_LOG(logger, Logger::DEBUG) << "Sending NBP_constrain residual of " << pool_diff
+                                 << " to deep ocean" << std::endl;
+    core->sendMessage(M_DUMP_TO_DEEP_OCEAN, D_OCEAN_C, message_data(-pool_diff));
 
     // Re-calculate atmosphere-land flux (NBP)
     alf = npp_total.value(U_PGC_YR) - rh_total.value(U_PGC_YR) -


### PR DESCRIPTION
When the model is running under a NBP constraint, it has a residual between the constraint value and the calculated NBP due to NPP + RH + LUC. This PR changes the model behavior so that the residual is sent to the deep ocean (following the behavior of the CO2 constraint) rather than added to or debited from the atmosphere, because the old behavior could result in runaway atmospheric CO2 under certain conditions. This was fully documented in #659 .

![p1](https://user-images.githubusercontent.com/1956468/204501064-e1d27222-1d47-4848-8311-46c92bd03410.png)

This does not change any behavior _except_ when running under this constraint.

Closes #659 
