### PR TITLE
Correct the cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 3.0.0-alpha
+cff-version: 3.0.0
 message: "If you use this software in your work, please cite it as below."
 authors:
 - family-names: "Dorheim"
@@ -31,7 +31,7 @@ authors:
   given-names: "Dawn"
   orcid: "https://orcid.org/0000-0002-0468-4660"
 title: "Hector a simple carbon-climate model"
-version: 3.0.0-alpha
-doi: TODO
-date-released: TODO
+version: 3.0.0
+doi: 10.5281/zenodo.7615632
+date-released: 2023-02-06
 url: "https://github.com/jgcri/hector"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hector 3.0.0
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7615632.svg)](https://doi.org/10.5281/zenodo.7615632)
+
 * Updated parameterization, incorporating latest consensus science and for best model performance relative to historical observations
 * New radiative forcing calculations for consistency with AR6
 * Better and more complete software tests; many bug fixes


### PR DESCRIPTION
@bpbond so there were errors in the cff file, which caused problems on the zenodo end of things. This PR is a documentation change that updates the cff with the zenodo release info however now those files are somewhat out of sink, but would enable the automatic zenodo release in the future so if we were to do a v3.0.1 think everything would be correct. 

Do we want to wait fro the v3.1.0 release or should we do a v 3.0.1 release? 