### PR TITLE
Update model version constant to 3.1.0

### DIFF
--- a/inst/include/h_util.hpp
+++ b/inst/include/h_util.hpp
@@ -26,7 +26,7 @@
  * \brief The model version number to be included in logs and outputs.
  * \note  Manually update the git tag to match this.
  */
-#define MODEL_VERSION "3.0.1"
+#define MODEL_VERSION "3.1.0"
 
 #define OUTPUT_DIRECTORY "output/"
 


### PR DESCRIPTION
I think this was missed in https://github.com/JGCRI/hector/pull/701/commits/e35f6b6fa5c4b222346264ef7a01d6dc9ab315af in https://github.com/JGCRI/hector/pull/701

I use this constant in Pyhector.