### PR TITLE
Don't run scheduled jobs on forks

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,9 +15,12 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-  
+
 jobs:
   R-CMD-check:
+    # Don't run scheduled job on forks, only in main repository.
+    if: (github.event_name == 'schedule' && github.repository == 'JGCRI/hector') || (github.event_name != 'schedule')
+
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -16,6 +16,8 @@ name: test-coverage
 
 jobs:
   test-coverage:
+    # Don't run scheduled job on forks, only in main repository.
+    if: (github.event_name == 'schedule' && github.repository == 'JGCRI/hector') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/command-line.yaml
+++ b/.github/workflows/command-line.yaml
@@ -21,10 +21,14 @@ on:
   workflow_dispatch:
 
 jobs:
+
   # This workflow contains two jobs, one that builds hector on ubuntu and the second
   # builds and tests Hector on macos. The purpose of this work for is to make sure that Hector
   # can be built from the command line.
   ubuntu:
+    # Don't run scheduled job on forks, only in main repository.
+    if: (github.event_name == 'schedule' && github.repository == 'JGCRI/hector') || (github.event_name != 'schedule')
+
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
Scheduled jobs should only run in the main repo.
Solution from https://github.com/orgs/community/discussions/26684

Let me know if you want me to experiment with the date for testing!

This closes #708 