### PR TITLE
Make the package versions consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hector 3.1.0 
+# hector 3.1.1 
 
 Return global mean surface temperature as a Hector output.
 

--- a/vignettes/articles/Permafrost.Rmd
+++ b/vignettes/articles/Permafrost.Rmd
@@ -151,4 +151,4 @@ ggplot(results, aes(year, value, color = param_value, group = paste(varying, par
     annotate(geom = "line", x = default$year, y = default$value, linewidth = 1.5)
 ```
 
-Hector's permafrost capability is planned to be fully science-ready in v3.1.
+Hector's permafrost capability is planned to be fully science-ready in v3.2.


### PR DESCRIPTION
As it was pointed out in the GMD editor's feedback, there are some inconsistent package versioning numbers. I am not quite sure how it happened but with this PR all the version numbers should be consistent and then we can do a release with the correct number/delete the release with the incorrect versioning number? @bpbond what do you think?  