### PR TITLE
Update CPP src/Makvars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
-CXX_STD = CXX11
+CXX_STD = CXX17
 PKG_CPPFLAGS = -I../inst/include -DUSE_RCPP


### PR DESCRIPTION
Bug Fix -- no change in model output behavior

This resolves #768; with the upgrade to BH 1.87, the R Hector package build failed locally and on GitHub Actions. Thanks to @pralitp for pointing out the problem with the src/Markvars file 

