### PR TITLE
Break out RH

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1298,6 +1298,12 @@ RH_DETRITUS <- function() {
     .Call('_hector_RH_DETRITUS', PACKAGE = 'hector')
 }
 
+#' @rdname carboncycle
+#' @export
+RH_SOIL <- function() {
+    .Call('_hector_RH_SOIL', PACKAGE = 'hector')
+}
+
 #' @describeIn parameters Preindustrial CO2 concentration (\code{"ppmv CO2"})
 #' @export
 PREINDUSTRIAL_CO2 <- function() {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1292,6 +1292,12 @@ RH <- function() {
     .Call('_hector_RH', PACKAGE = 'hector')
 }
 
+#' @rdname carboncycle
+#' @export
+RH_DETRITUS <- function() {
+    .Call('_hector_RH_DETRITUS', PACKAGE = 'hector')
+}
+
 #' @describeIn parameters Preindustrial CO2 concentration (\code{"ppmv CO2"})
 #' @export
 PREINDUSTRIAL_CO2 <- function() {

--- a/inst/include/simpleNbox.hpp
+++ b/inst/include/simpleNbox.hpp
@@ -140,6 +140,8 @@ private:
       final_npp; //!< final NPP after any NBP constraint accounted for, Pg C/yr
   fluxpool_stringmap
       final_rh; //!< final RH after any NBP constraint accounted for, Pg C/yr
+  fluxpool_stringmap
+      final_rh_detritus; //!< final RH after any NBP constraint accounted for, Pg C/yr
 
   // Other state variables
   unitval Ca_residual; //!< residual (when constraining [CO2]), Pg C
@@ -175,6 +177,8 @@ private:
       final_npp_tv; //!< Time series of biome-specific final NPP
   tvector<fluxpool_stringmap>
       final_rh_tv; //!< Time series of biome-specific final RH
+  tvector<fluxpool_stringmap>
+      final_rh_detritus_tv; //!< Time series of biome-specific final RH
 
   tseries<unitval> Ca_residual_ts; //!< Time series of residual flux values
 

--- a/inst/include/simpleNbox.hpp
+++ b/inst/include/simpleNbox.hpp
@@ -142,6 +142,8 @@ private:
       final_rh; //!< final RH after any NBP constraint accounted for, Pg C/yr
   fluxpool_stringmap
       final_rh_detritus; //!< final RH after any NBP constraint accounted for, Pg C/yr
+  fluxpool_stringmap
+      final_rh_soil; //!< final RH after any NBP constraint accounted for, Pg C/yr
 
   // Other state variables
   unitval Ca_residual; //!< residual (when constraining [CO2]), Pg C
@@ -179,6 +181,8 @@ private:
       final_rh_tv; //!< Time series of biome-specific final RH
   tvector<fluxpool_stringmap>
       final_rh_detritus_tv; //!< Time series of biome-specific final RH
+  tvector<fluxpool_stringmap>
+      final_rh_soil_tv; //!< Time series of biome-specific final RH
 
   tseries<unitval> Ca_residual_ts; //!< Time series of residual flux values
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2180,6 +2180,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// RH_SOIL
+String RH_SOIL();
+RcppExport SEXP _hector_RH_SOIL() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(RH_SOIL());
+    return rcpp_result_gen;
+END_RCPP
+}
 // PREINDUSTRIAL_CO2
 String PREINDUSTRIAL_CO2();
 RcppExport SEXP _hector_PREINDUSTRIAL_CO2() {
@@ -2982,6 +2992,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_hector_NPP", (DL_FUNC) &_hector_NPP, 0},
     {"_hector_RH", (DL_FUNC) &_hector_RH, 0},
     {"_hector_RH_DETRITUS", (DL_FUNC) &_hector_RH_DETRITUS, 0},
+    {"_hector_RH_SOIL", (DL_FUNC) &_hector_RH_SOIL, 0},
     {"_hector_PREINDUSTRIAL_CO2", (DL_FUNC) &_hector_PREINDUSTRIAL_CO2, 0},
     {"_hector_ATMOSPHERIC_CO2", (DL_FUNC) &_hector_ATMOSPHERIC_CO2, 0},
     {"_hector_FFI_EMISSIONS", (DL_FUNC) &_hector_FFI_EMISSIONS, 0},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2170,6 +2170,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// RH_DETRITUS
+String RH_DETRITUS();
+RcppExport SEXP _hector_RH_DETRITUS() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(RH_DETRITUS());
+    return rcpp_result_gen;
+END_RCPP
+}
 // PREINDUSTRIAL_CO2
 String PREINDUSTRIAL_CO2();
 RcppExport SEXP _hector_PREINDUSTRIAL_CO2() {
@@ -2971,6 +2981,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_hector_CONCENTRATIONS_CO2", (DL_FUNC) &_hector_CONCENTRATIONS_CO2, 0},
     {"_hector_NPP", (DL_FUNC) &_hector_NPP, 0},
     {"_hector_RH", (DL_FUNC) &_hector_RH, 0},
+    {"_hector_RH_DETRITUS", (DL_FUNC) &_hector_RH_DETRITUS, 0},
     {"_hector_PREINDUSTRIAL_CO2", (DL_FUNC) &_hector_PREINDUSTRIAL_CO2, 0},
     {"_hector_ATMOSPHERIC_CO2", (DL_FUNC) &_hector_ATMOSPHERIC_CO2, 0},
     {"_hector_FFI_EMISSIONS", (DL_FUNC) &_hector_FFI_EMISSIONS, 0},

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -174,6 +174,7 @@ void CSVOutputStreamVisitor::visit(SimpleNbox *c) {
   STREAM_UNITVAL(csvFile, c, D_NPP, c->final_npp[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH, c->final_rh[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH_DETRITUS, c->final_rh_detritus[SNBOX_DEFAULT_BIOME]);
+  STREAM_UNITVAL(csvFile, c, D_RH_SOIL, c->final_rh_soil[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH_CH4, c->final_rh[SNBOX_DEFAULT_BIOME]);
   STREAM_MESSAGE_DATE(csvFile, c, D_CO2_CONC, current_date);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_CO2);

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -173,6 +173,7 @@ void CSVOutputStreamVisitor::visit(SimpleNbox *c) {
   STREAM_MESSAGE(csvFile, c, D_NBP);
   STREAM_UNITVAL(csvFile, c, D_NPP, c->final_npp[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH, c->final_rh[SNBOX_DEFAULT_BIOME]);
+  STREAM_UNITVAL(csvFile, c, D_RH_DETRITUS, c->final_rh_detritus[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH_CH4, c->final_rh[SNBOX_DEFAULT_BIOME]);
   STREAM_MESSAGE_DATE(csvFile, c, D_CO2_CONC, current_date);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_CO2);

--- a/src/rcpp_constants.cpp
+++ b/src/rcpp_constants.cpp
@@ -1133,6 +1133,11 @@ String RH() { return D_RH; }
 // [[Rcpp::export]]
 String RH_DETRITUS() { return D_RH_DETRITUS; }
 
+//' @rdname carboncycle
+//' @export
+// [[Rcpp::export]]
+String RH_SOIL() { return D_RH_SOIL; }
+
 //' @describeIn parameters Preindustrial CO2 concentration (\code{"ppmv CO2"})
 //' @export
 // [[Rcpp::export]]

--- a/src/rcpp_constants.cpp
+++ b/src/rcpp_constants.cpp
@@ -1128,6 +1128,11 @@ String NPP() { return D_NPP; }
 // [[Rcpp::export]]
 String RH() { return D_RH; }
 
+//' @rdname carboncycle
+//' @export
+// [[Rcpp::export]]
+String RH_DETRITUS() { return D_RH_DETRITUS; }
+
 //' @describeIn parameters Preindustrial CO2 concentration (\code{"ppmv CO2"})
 //' @export
 // [[Rcpp::export]]

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -442,6 +442,7 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
 
     final_rh[biome] =
         rh_fda_adj + rh_fsa_adj + rh_ftpa_co2_adj + rh_ftpa_ch4_adj; // per year
+    final_rh_detritus[biome] = rh_fda_adj;
     // Note that the following fluxes are weighted by 'yf' (year fraction)
     fluxpool rh_fda_flux =
         yf * detritus_c[biome].flux_from_fluxpool(rh_fda_adj);
@@ -477,6 +478,8 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
     // simpleNbox's point of view). In order not to trigger a mass balance
     // issue, we track it and adjust in the mass balance check below
     cumulative_pf_ch4 += rh_fpa_ch4_flux.value(U_PGC);
+    //final_rh_detritus[biome] = rh_fda_flux; I don't think this is the right one but woudl like to confirm... 
+
 
     // Permafrost thaw and refreeze
     if (!in_spinup) {

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -479,9 +479,6 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
     // simpleNbox's point of view). In order not to trigger a mass balance
     // issue, we track it and adjust in the mass balance check below
     cumulative_pf_ch4 += rh_fpa_ch4_flux.value(U_PGC);
-    //final_rh_detritus[biome] = rh_fda_flux; I don't think this is the right one but woudl like to confirm...
-    //final_rh_soil[biome] = rh_fsa_flux; I don't think this is the right one but woudl like to confirm...
-
 
     // Permafrost thaw and refreeze
     if (!in_spinup) {

--- a/src/simpleNbox-runtime.cpp
+++ b/src/simpleNbox-runtime.cpp
@@ -443,6 +443,7 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
     final_rh[biome] =
         rh_fda_adj + rh_fsa_adj + rh_ftpa_co2_adj + rh_ftpa_ch4_adj; // per year
     final_rh_detritus[biome] = rh_fda_adj;
+    final_rh_soil[biome] = rh_fsa_adj;
     // Note that the following fluxes are weighted by 'yf' (year fraction)
     fluxpool rh_fda_flux =
         yf * detritus_c[biome].flux_from_fluxpool(rh_fda_adj);
@@ -478,7 +479,8 @@ void SimpleNbox::stashCValues(double t, const double c[]) {
     // simpleNbox's point of view). In order not to trigger a mass balance
     // issue, we track it and adjust in the mass balance check below
     cumulative_pf_ch4 += rh_fpa_ch4_flux.value(U_PGC);
-    //final_rh_detritus[biome] = rh_fda_flux; I don't think this is the right one but woudl like to confirm... 
+    //final_rh_detritus[biome] = rh_fda_flux; I don't think this is the right one but woudl like to confirm...
+    //final_rh_soil[biome] = rh_fsa_flux; I don't think this is the right one but woudl like to confirm...
 
 
     // Permafrost thaw and refreeze

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -105,6 +105,7 @@ void SimpleNbox::init(Core *coreptr) {
   final_npp[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_npp");
   final_rh[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_rh");
   final_rh_detritus[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_rh_detritus");
+  final_rh_soil[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_rh_soil");
   RH_ch4[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "RH_ch4");
 
   // Constraint residuals
@@ -689,6 +690,9 @@ unitval SimpleNbox::getData(const std::string &varName, const double date) {
   } else if (varNameParsed == D_RH_DETRITUS) {
       returnval =
           sum_fluxpool_biome_ts(varName, date, biome, final_rh_detritus, final_rh_detritus_tv);
+  } else if (varNameParsed == D_RH_SOIL) {
+      returnval =
+          sum_fluxpool_biome_ts(varName, date, biome, final_rh_soil, final_rh_soil_tv);
   } else if (varNameParsed == D_RH_CH4) {
     returnval = sum_fluxpool_biome_ts(varName, date, biome, RH_ch4, RH_ch4_tv);
   } else {
@@ -714,6 +718,7 @@ void SimpleNbox::reset(double time) {
   final_npp = final_npp_tv.get(time);
   final_rh = final_rh_tv.get(time);
   final_rh_detritus = final_rh_detritus_tv.get(time);
+  final_rh_soil = final_rh_soil_tv.get(time);
   RH_thawed_permafrost = RH_thawed_permafrost_tv.get(time);
   RH_ch4 = RH_ch4_tv.get(time);
 
@@ -752,6 +757,7 @@ void SimpleNbox::reset(double time) {
   final_npp_tv.truncate(time);
   final_rh_tv.truncate(time);
   final_rh_detritus_tv.truncate(time);
+  final_rh_soil_tv.truncate(time);
   RH_thawed_permafrost_tv.truncate(time);
   RH_ch4_tv.truncate(time);
 
@@ -818,6 +824,7 @@ void SimpleNbox::record_state(double t) {
   final_npp_tv.set(t, final_npp);
   final_rh_tv.set(t, final_rh);
   final_rh_detritus_tv.set(t, final_rh_detritus);
+  final_rh_soil_tv.set(t, final_rh_soil);
 
   Ca_residual_ts.set(t, Ca_residual);
 
@@ -982,8 +989,11 @@ void SimpleNbox::deleteBiome(
   remove_biome_from_ts(final_npp_tv, biome);
   final_rh.erase(biome);
   final_rh_detritus.erase(biome);
+  final_rh_soil.erase(biome);
   remove_biome_from_ts(final_rh_tv, biome);
   remove_biome_from_ts(final_rh_detritus_tv, biome);
+  remove_biome_from_ts(final_rh_soil_tv, biome);
+
 
   // Others
   npp_flux0.erase(biome);
@@ -1085,6 +1095,9 @@ void SimpleNbox::renameBiome(const std::string &oldname,
   final_rh_detritus[newname] = final_rh_detritus.at(oldname);
   final_rh_detritus.erase(oldname);
   rename_biome_in_ts(final_rh_detritus_tv, oldname, newname);
+  final_rh_soil[newname] = final_rh_soil.at(oldname);
+  final_rh_soil.erase(oldname);
+  rename_biome_in_ts(final_rh_soil_tv, oldname, newname);
 
   npp_flux0[newname] = npp_flux0.at(oldname);
   npp_flux0.erase(oldname);

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -717,8 +717,6 @@ void SimpleNbox::reset(double time) {
   thawed_permafrost_c = thawed_permafrost_c_tv.get(time);
   final_npp = final_npp_tv.get(time);
   final_rh = final_rh_tv.get(time);
-  final_rh_detritus = final_rh_detritus_tv.get(time);
-  final_rh_soil = final_rh_soil_tv.get(time);
   RH_thawed_permafrost = RH_thawed_permafrost_tv.get(time);
   RH_ch4 = RH_ch4_tv.get(time);
 

--- a/src/simpleNbox.cpp
+++ b/src/simpleNbox.cpp
@@ -104,6 +104,7 @@ void SimpleNbox::init(Core *coreptr) {
 
   final_npp[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_npp");
   final_rh[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_rh");
+  final_rh_detritus[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "final_rh_detritus");
   RH_ch4[SNBOX_DEFAULT_BIOME] = fluxpool(0.0, U_PGC_YR, false, "RH_ch4");
 
   // Constraint residuals
@@ -685,6 +686,9 @@ unitval SimpleNbox::getData(const std::string &varName, const double date) {
   } else if (varNameParsed == D_RH) {
     returnval =
         sum_fluxpool_biome_ts(varName, date, biome, final_rh, final_rh_tv);
+  } else if (varNameParsed == D_RH_DETRITUS) {
+      returnval =
+          sum_fluxpool_biome_ts(varName, date, biome, final_rh_detritus, final_rh_detritus_tv);
   } else if (varNameParsed == D_RH_CH4) {
     returnval = sum_fluxpool_biome_ts(varName, date, biome, RH_ch4, RH_ch4_tv);
   } else {
@@ -709,6 +713,7 @@ void SimpleNbox::reset(double time) {
   thawed_permafrost_c = thawed_permafrost_c_tv.get(time);
   final_npp = final_npp_tv.get(time);
   final_rh = final_rh_tv.get(time);
+  final_rh_detritus = final_rh_detritus_tv.get(time);
   RH_thawed_permafrost = RH_thawed_permafrost_tv.get(time);
   RH_ch4 = RH_ch4_tv.get(time);
 
@@ -717,7 +722,7 @@ void SimpleNbox::reset(double time) {
   tempferts = tempferts_tv.get(time);
   tempfertd = tempfertd_tv.get(time);
   f_frozen = f_frozen_tv.get(time);
-  
+
   cum_luc_va = cum_luc_va_ts.get(time);
 
   // Calculate derived quantities
@@ -746,6 +751,7 @@ void SimpleNbox::reset(double time) {
 
   final_npp_tv.truncate(time);
   final_rh_tv.truncate(time);
+  final_rh_detritus_tv.truncate(time);
   RH_thawed_permafrost_tv.truncate(time);
   RH_ch4_tv.truncate(time);
 
@@ -811,13 +817,14 @@ void SimpleNbox::record_state(double t) {
 
   final_npp_tv.set(t, final_npp);
   final_rh_tv.set(t, final_rh);
+  final_rh_detritus_tv.set(t, final_rh_detritus);
 
   Ca_residual_ts.set(t, Ca_residual);
 
   tempfertd_tv.set(t, tempfertd);
   tempferts_tv.set(t, tempferts);
   f_frozen_tv.set(t, f_frozen);
-  
+
   cum_luc_va_ts.set(t, cum_luc_va);
 
   H_LOG(logger, Logger::DEBUG)
@@ -896,7 +903,7 @@ void SimpleNbox::createBiome(const std::string &biome) {
   f_frozen[biome] = 1.0;
   add_biome_to_ts(f_frozen_tv, biome, 1.0);
   f_new_thaw[biome] = 0.0;
-  
+
   std::string last_biome = biome_list.back();
 
   // Set parameters to same as most recent biome
@@ -911,7 +918,7 @@ void SimpleNbox::createBiome(const std::string &biome) {
   pf_mu[biome] = pf_mu[last_biome];
   fpf_static[biome] = fpf_static[last_biome];
   // pf_s will get recomputed when the core is reset
-  
+
   // Add to end of biome list
   biome_list.push_back(biome);
 
@@ -946,7 +953,7 @@ void SimpleNbox::deleteBiome(
   pf_mu.erase(biome);
   fpf_static.erase(biome);
   pf_s.erase(biome);
-  
+
   // C pools
   veg_c.erase(biome);
   remove_biome_from_ts(veg_c_tv, biome);
@@ -974,7 +981,9 @@ void SimpleNbox::deleteBiome(
   final_npp.erase(biome);
   remove_biome_from_ts(final_npp_tv, biome);
   final_rh.erase(biome);
+  final_rh_detritus.erase(biome);
   remove_biome_from_ts(final_rh_tv, biome);
+  remove_biome_from_ts(final_rh_detritus_tv, biome);
 
   // Others
   npp_flux0.erase(biome);
@@ -986,7 +995,7 @@ void SimpleNbox::deleteBiome(
   f_frozen.erase(biome);
   remove_biome_from_ts(f_frozen_tv, biome);
   f_new_thaw.erase(biome);
-  
+
   // Remove from `biome_list`
   biome_list.erase(i_biome);
 
@@ -1019,7 +1028,7 @@ void SimpleNbox::renameBiome(const std::string &oldname,
   f_nppd.erase(oldname);
   f_litterd[newname] = f_litterd.at(oldname);
   f_litterd.erase(oldname);
-  
+
   rh_ch4_frac[newname] = rh_ch4_frac.at(oldname);
   rh_ch4_frac.erase(oldname);
   pf_sigma[newname] = pf_sigma.at(oldname);
@@ -1030,7 +1039,7 @@ void SimpleNbox::renameBiome(const std::string &oldname,
   fpf_static.erase(oldname);
   pf_s[newname] = pf_s.at(oldname);
   pf_s.erase(oldname);
-  
+
   H_LOG(logger, Logger::DEBUG) << "Transferring C from biome '" << oldname
                                << "' to '" << newname << "'." << std::endl;
 
@@ -1073,6 +1082,9 @@ void SimpleNbox::renameBiome(const std::string &oldname,
   final_rh[newname] = final_rh.at(oldname);
   final_rh.erase(oldname);
   rename_biome_in_ts(final_rh_tv, oldname, newname);
+  final_rh_detritus[newname] = final_rh_detritus.at(oldname);
+  final_rh_detritus.erase(oldname);
+  rename_biome_in_ts(final_rh_detritus_tv, oldname, newname);
 
   npp_flux0[newname] = npp_flux0.at(oldname);
   npp_flux0.erase(oldname);


### PR DESCRIPTION
Hector user Guillemette Legrand asked for the ability to look at Rh soil and detritus results. This PR addresses the request. 

Now users can take a look at `rh_det` and `rh_soil` see the plot below 

![image](https://github.com/user-attachments/assets/443ac521-f476-416d-916e-a8f99e79044e)


[testing_rh.R.zip](https://github.com/user-attachments/files/19151576/testing_rh.R.zip)


This PR does not affect Hector's numerical results and does not add a new feature but allows users access to an already existing capability. 