### PR TITLE
Warning fixes when compiling with g++

### DIFF
--- a/inst/include/core.hpp
+++ b/inst/include/core.hpp
@@ -105,8 +105,8 @@ public:
   static int mkcore(bool logtofile = false,
                     Logger::LogLevel loglvl = Logger::NOTICE,
                     bool logtoscrn = false);
-  static Core *getcore(int idx);
-  static void delcore(int idx);
+  static Core *getcore(std::vector<Core *>::size_type idx);
+  static void delcore(std::vector<Core *>::size_type idx);
 
   std::vector<std::string> getBiomeList() const;
   void createBiome(const std::string &biome);

--- a/misc/main-api.cpp
+++ b/misc/main-api.cpp
@@ -151,7 +151,7 @@ int main (int argc, char * const argv[]) {
         H_LOG( glog, Logger::NOTICE ) << "Hector wrapper end" << endl;
         glog.close();
     }
-    catch( h_exception e ) {
+    catch( h_exception &e ) {
       cerr << "* Program exception:\n" << e << endl;
     }
     catch( std::exception &e ) {

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -832,7 +832,7 @@ int Core::mkcore(bool logtofile, Logger::LogLevel loglvl, bool logtoscrn) {
  * \details Return a pointer to the core corresponding to the input
  * index.  If an invalid index is passed, return a null pointer.
  */
-Core *Core::getcore(int idx) {
+Core *Core::getcore(std::vector<Core *>::size_type idx) {
   if (idx < core_registry.size() && idx >= 0) {
     return core_registry[idx];
   } else {
@@ -845,7 +845,7 @@ Core *Core::getcore(int idx) {
  * and set its entry in the registry to a null pointer. If an invalid
  * index is passed, this is a no-op.
  */
-void Core::delcore(int idx) {
+void Core::delcore(std::vector<Core *>::size_type idx) {
   Core *core = getcore(idx);
 
   if (core) {

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -184,7 +184,7 @@ void Core::init() {
   for (auto mc : modelComponents) {
     try {
       mc.second->init(this);
-    } catch (h_exception e) {
+    } catch (h_exception &e) {
       H_LOG(glog, Logger::SEVERE)
           << "error initializing component " << mc.first;
       throw;

--- a/src/csv_table_reader.cpp
+++ b/src/csv_table_reader.cpp
@@ -48,7 +48,7 @@ CSVTableReader::CSVTableReader(const string &fileName) : fileName(fileName) {
   try {
     // attempt to open the file
     tableInputStream.open(fileName.c_str());
-  } catch (ifstream::failure e) {
+  } catch (ifstream::failure &e) {
     // the macro errno in combination with strerror seem to be much more
     // informative than error message from the exception
     string errorStr =
@@ -66,7 +66,7 @@ CSVTableReader::CSVTableReader(const string &fileName) : fileName(fileName) {
 CSVTableReader::~CSVTableReader() {
   try {
     tableInputStream.close();
-  } catch (ifstream::failure e) {
+  } catch (ifstream::failure &e) {
     // ignoring close errors
   }
 }
@@ -183,7 +183,7 @@ void CSVTableReader::process(Core *core, const string &componentName,
       }
     }
 
-  } catch (ifstream::failure e) {
+  } catch (ifstream::failure &e) {
     string errorStr = "I/O exception while processing " + fileName +
                       " error: " + strerror(errno);
     H_THROW(errorStr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *const argv[]) {
 
     H_LOG(glog, Logger::NOTICE) << "Hector wrapper end" << endl;
     glog.close();
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     cerr << "* Program exception:\n" << e << endl;
     return 1;
   } catch (std::exception &e) {

--- a/src/rcpp_hector.cpp
+++ b/src/rcpp_hector.cpp
@@ -53,7 +53,7 @@ Environment newcore_impl(String inifile, int loglevel, bool suppresslogging,
     try {
       Hector::INIToCoreReader coreParser(hcore);
       coreParser.parse(inifile);
-    } catch (h_exception e) {
+    } catch (h_exception &e) {
       std::stringstream msg;
       msg << "While parsing hector input file " << fn << ": " << e;
       Rcpp::stop(msg.str());
@@ -78,7 +78,7 @@ Environment newcore_impl(String inifile, int loglevel, bool suppresslogging,
     rv["reset_date"] = 0;
 
     return rv;
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     std::stringstream msg;
     msg << "During hector core setup: " << e;
     Rcpp::stop(msg.str());
@@ -125,7 +125,7 @@ Environment reset(Environment core, double date = 0) {
   Hector::Core *hcore = gethcore(core);
   try {
     hcore->reset(date);
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     std::stringstream msg;
     msg << "Error resetting to date= " << date << " :  " << e;
     Rcpp::stop(msg.str());
@@ -171,7 +171,7 @@ Environment run(Environment core, double runtodate = -1.0) {
 
   try {
     hcore->run(runtodate);
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     std::stringstream msg;
     msg << "Error while running hector:  " << e;
     Rcpp::stop(msg.str());
@@ -296,7 +296,7 @@ DataFrame sendmessage(Environment core, String msgtype, String capability,
   Hector::unit_types utype;
   try {
     utype = Hector::unitval::parseUnitsName(unitstr);
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     // Units need to be specified in setData and incorrect pr missing units will
     // throw an error
     if (msgstr == M_SETDATA) {
@@ -340,7 +340,7 @@ DataFrame sendmessage(Environment core, String msgtype, String capability,
       unitsout[i] = rtn.unitsName();
       valueout[i] = rtn.value(rtn.units());
     }
-  } catch (h_exception e) {
+  } catch (h_exception &e) {
     std::stringstream emsg;
     emsg << "sendmessage: " << e;
     Rcpp::stop(emsg.str());

--- a/src/unit-testing/test_ini_to_core_reader.cpp
+++ b/src/unit-testing/test_ini_to_core_reader.cpp
@@ -136,7 +136,7 @@ TEST_F(TestINIToCore, TableFilenameNoPrefix) {
     // a nonexistent file
     try {
         reader.parse(testFileName);
-    } catch( h_exception e) {
+    } catch( h_exception &e) {
         // we should get and exception from dummy model component when it
         // tries to set c to a single value
         ASSERT_EQ( e.get_filename(), "dummy_model_component.cpp" );
@@ -148,7 +148,7 @@ TEST_F(TestINIToCore, TableFilenameWithCSVPrefix) {
     testFile << "c=csv:non_existent.csv" << std::endl;
     try {
         reader.parse(testFileName);
-    } catch( h_exception e ) {
+    } catch( h_exception &e ) {
         // looking for an exception from CSVTableReader which indicates that it
         // understood to try to read a CSV file
         ASSERT_EQ( e.get_filename(), "csv_table_reader.cpp" );


### PR DESCRIPTION
Two changes to eliminate warnings from `g++`:

* Use references for exception objects per the C++ Core Guidelines:
   https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-exception-ref
* Use `vector<Core *>::size_type` as index type for `getcore` and `delcore` methods to avoid signed/unsigned comparisons.