### PR TITLE
Add H2 indirect effects on trop O3

### DIFF
--- a/inst/include/component_data.hpp
+++ b/inst/include/component_data.hpp
@@ -66,6 +66,7 @@
 #define D_RHO_SO2 "rho_so2"          // SO2 radiative efficiency
 #define D_RHO_NH3 "rho_nh3"          // NH3 radiative efficiency
 #define D_RHO_H2O_H2 "rho_h2o_h2"    // radiative efficiency of H2 emissions on strat. H2O vapor
+#define D_RHO_O3_H2 "rho_o3_h2"      // radiative efficiency of H2 emissions on trop. O3
 
 
 // halocarbon components

--- a/inst/include/forcing_component.hpp
+++ b/inst/include/forcing_component.hpp
@@ -112,6 +112,9 @@ private:
   // Stratospheric water vapor (strat. H2O) parameters
   unitval rho_h2o_h2; // W m −2 per Tg yr− 1 from Sand et al. 2023
 
+  // Tropospheric Ozone (trop. O3) parameters
+  unitval rho_o3_h2; // W m −2 per Tg yr− 1 from Sand et al. 2023
+
   // Aerosol parameters for aerosol-radiation interactions (RFari) see
   // equation 7.SM.1.1 of IPCC AR6
   unitval rho_bc; // (W yr m–2 Tg–1) IPCC AR6 radiative efficiency BC 7.SM.1.3

--- a/inst/input/hector_picontrol.ini
+++ b/inst/input/hector_picontrol.ini
@@ -161,6 +161,8 @@ rho_oc=-.00621          ; (W yr m–2 C Tg–1) IPCC AR6 radiative efficiency OC
 rho_so2=-.00000724      ; (W yr m–2 S Gg-1) IPCC AR6 radiative efficiency SO2 (7.SM.1.3.1 of IPCC AR6)
 rho_nh3=-.00208         ; (W yr m–2 NH3Tg–1) IPCC AR6 radiative efficiency NH3 (7.SM.1.3.1 of IPCC AR6)
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings default set to 0, or read in from a input table, may be used to read in

--- a/inst/input/hector_ssp119.ini
+++ b/inst/input/hector_ssp119.ini
@@ -173,6 +173,7 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp126.ini
+++ b/inst/input/hector_ssp126.ini
@@ -173,6 +173,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp245.ini
+++ b/inst/input/hector_ssp245.ini
@@ -174,6 +174,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 

--- a/inst/input/hector_ssp370.ini
+++ b/inst/input/hector_ssp370.ini
@@ -174,6 +174,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp434.ini
+++ b/inst/input/hector_ssp434.ini
@@ -174,6 +174,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp460.ini
+++ b/inst/input/hector_ssp460.ini
@@ -174,6 +174,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp534-over.ini
+++ b/inst/input/hector_ssp534-over.ini
@@ -174,6 +174,7 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to

--- a/inst/input/hector_ssp585.ini
+++ b/inst/input/hector_ssp585.ini
@@ -173,6 +173,8 @@ rho_oc=-0.006407143     ; (W yr m–2 C Tg–1) Dorheim et al. 2024
 rho_so2=-7.469841e-06   ; (W yr m–2 S Gg-1) Dorheim et al. 2024
 rho_nh3=-0.002146032    ; (W yr m–2 NH3Tg–1) Dorheim et al. 2024
 rho_h2o_h2=0.00019      ; (W m −2 H2 Tg−1) from Sand et al. 2023
+rho_o3_h2=0.3827	; (W m −2 H2 Tg−1) from Sand et al. 2023
+
 
 
 ; Miscellaneous radiative forcings are by default zero, but can read in from a input table to


### PR DESCRIPTION
This PR is intended to address [H2 Project Issue Issue 4 ](https://github.com/orgs/JGCRI/projects/7?pane=issue&itemId=72654984&issue=JGCRI%7CHector_H2_Project%7C4). It adds the indirect effect of H2 on top O3 RF. 