### PR TITLE
Time varying natural CH4 emissions

### DIFF
--- a/inst/include/ch4_component.hpp
+++ b/inst/include/ch4_component.hpp
@@ -59,9 +59,9 @@ private:
   tseries<unitval> CH4_emissions;
   tseries<unitval> CH4;           // CH4 concentrations, ppbv CH4
   tseries<unitval> CH4_constrain; // CH4 concentration constraint, ppbv CH4
+  tseries<unitval> CH4N;          // annual natural emissions, Tg CH4/yr
   unitval M0;                     // preindustrial methane, ppbv CH4
   unitval UC_CH4; // conversion factor between emissions and concentration
-  unitval CH4N;   // annual natural emissions, Tg CH4/yr
   unitval Tsoil;  // lifetime of soil sink, yr
   unitval Tstrat; // lifetime of tropospheric sink, yr
 

--- a/inst/input/hector_picontrol.ini
+++ b/inst/input/hector_picontrol.ini
@@ -109,7 +109,7 @@ M0=731.41  			; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          		; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=0			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions[1745]=337.7313     ; emissions time series
 
 ;------------------------------------------------------------------------

--- a/inst/input/hector_ssp119.ini
+++ b/inst/input/hector_ssp119.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp119_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp119_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp126.ini
+++ b/inst/input/hector_ssp126.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp126_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp126_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp245.ini
+++ b/inst/input/hector_ssp245.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp245_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp245_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp370.ini
+++ b/inst/input/hector_ssp370.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp370_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp370_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp434.ini
+++ b/inst/input/hector_ssp434.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp434_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp434_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp460.ini
+++ b/inst/input/hector_ssp460.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp460_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp460_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp534-over.ini
+++ b/inst/input/hector_ssp534-over.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp534-over_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp534-over_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/inst/input/hector_ssp585.ini
+++ b/inst/input/hector_ssp585.ini
@@ -121,7 +121,7 @@ M0= 731.41  		; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4 
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          ; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=335			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=335			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:tables/ssp585_emiss-constraints_rf.csv     ; emissions time series
 ;CH4_constrain=csv:tables/ssp585_emiss-constraints_rf.csv    ; CH4 concentration constraint
 

--- a/src/ch4_component.cpp
+++ b/src/ch4_component.cpp
@@ -115,8 +115,8 @@ void CH4Component::setData(const string &varName, const message_data &data) {
       H_ASSERT(data.date == Core::undefinedIndex(), "date not allowed");
       UC_CH4 = data.getUnitval(U_TG_PPBV);
     } else if (varName == D_NATURAL_CH4) {
-      H_ASSERT(data.date == Core::undefinedIndex(), "date not allowed");
-      CH4N = data.getUnitval(U_TG_CH4);
+      H_ASSERT(data.date != Core::undefinedIndex(), "date required");
+      CH4N.set(data.date, data.getUnitval(U_TG_CH4));
     } else if (varName == D_CONSTRAINT_CH4) {
       H_ASSERT(data.date != Core::undefinedIndex(),
                "date required for CH4 concentration constraint");
@@ -170,7 +170,7 @@ void CH4Component::run(const double runToDate) {
         core->sendMessage(M_GETDATA, D_RH_CH4).value(U_PGC_YR) * PG_C_TO_TG_CH4;
 
     // Additional, background CH4 natural emissions
-    const double ch4n = CH4N.value(U_TG_CH4);
+    const double ch4n = CH4N.get(runToDate).value(U_TG_CH4);
     const double emisTocon =
         (current_ch4em + rh_ch4 + ch4n) / UC_CH4.value(U_TG_PPBV);
     const double previous_ch4 = CH4.get(oldDate);
@@ -214,9 +214,9 @@ unitval CH4Component::getData(const std::string &varName, const double date) {
     H_ASSERT(date != Core::undefinedIndex(), "Date required for CH4 emissions");
     returnval = CH4_emissions.get(date);
   } else if (varName == D_NATURAL_CH4) {
-    H_ASSERT(date == Core::undefinedIndex(),
-             "Date not allowed for natural CH4 emissions");
-    returnval = CH4N;
+    H_ASSERT(date != Core::undefinedIndex(),
+             "Date required for natural CH4 emissions");
+    returnval = CH4N.get(date);
   } else if (varName == D_LIFETIME_SOIL) {
     H_ASSERT(date == Core::undefinedIndex(),
              "Date not allowed for CH4 soil lifetime");

--- a/tests/testthat/input/luc_pulse.ini
+++ b/tests/testthat/input/luc_pulse.ini
@@ -101,7 +101,7 @@ M0= 731.41  			; 731.41 ppb preindustrial methane IPCC AR6 Table 7.SM.1, the CH4
 Tsoil=160 			; lifetime of soil sink (years)
 Tstrat=120          		; lifetime of tropospheric sink (years)
 UC_CH4=2.78			; Tg(CH4)/ppb unit conversion between emissions and concentrations
-CH4N=338			; Natural CH4 emissions (Tgrams)
+CH4N[1750]=338			; Natural CH4 emissions (Tgrams)
 CH4_emissions=csv:luc_pulse_tables.csv     ; emissions time series
 ;CH4_constrain=csv:luc_pulse_tables.csv    ; CH4 concentration constraint
 

--- a/tests/testthat/test_old-new.R
+++ b/tests/testthat/test_old-new.R
@@ -11,7 +11,7 @@ test_that("Hector output passes old new test", {
   # the old and new hector output must be less than the defined threshold.
   error_threshold <- 1e-10
 
-  # Read in the comparison data and extract the information to save.
+  # Read in the comparison data and extract the information to save.c
   comp_data <- read.csv("compdata/hector_comp.csv", stringsAsFactors = FALSE)
   vars <- unique(comp_data$variable)
 


### PR DESCRIPTION
Currently, natural CH4 emissions are held constant throughout the simulation run. This pull request introduces a new capability that will enable these emissions to be represented as a time series. Although there is no immediate change in the behavior (natural CH4 emissions remain constant), this development lays the groundwork for potential future adjustments where natural CH4 emissions can vary over time.

The following figures demonstrate this new capability. The time-varying natural CH4 emissions time series was randomly generated.

The anthropogenic CH4 emissions (left) do not change, whereas the natural emissions (right) are different between the two hector runs. 

![ch4_emissions](https://github.com/user-attachments/assets/1e819770-debe-4c3d-a2c6-078e71a03c46)


The time-varying natural emissions affect CH4 concentrations and global temperature. 
![CH4_concentration](https://github.com/user-attachments/assets/2f6d470e-8755-4303-a5ae-4c39c84439c1)

![global_tas](https://github.com/user-attachments/assets/ee41aac6-00f1-4d9a-be2e-a9ccbf7ace7b)


**** 

[PR_782.zip](https://github.com/user-attachments/files/20527926/PR_782.zip)
