### PR TITLE
Update H2 related parameters

### DIFF
--- a/data-raw/input_params.csv
+++ b/data-raw/input_params.csv
@@ -82,7 +82,7 @@ OH,CCH4,n,n,y,-0.32,,coefficient for CH4
 OH,H2_CCO,n,n,y,4.25,, H2 adjustment for CO coefficient
 OH,H2_emissions[1745],n,y,y,0,,emissions time series
 ozone,PO3,n,n,y,30,,preindustrial O3 concentration
-ozone,CO3_H2,n,n,y,4.09E-03,DU O3 Tg H2-1,coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand
+ozone,CO3_H2,n,n,y,4.09E-03,DU O3 Tg H2-1,"coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8"
 ozone,NOX_emissions,n,y,y,"""(csv)""",,emissions time series
 ozone,CO_emissions,n,y,y,"""(csv)""",,emissions time series
 ozone,H2_emissions[1745],n,y,y,0,,emissions time series
@@ -102,7 +102,7 @@ forcing,rho_bc,n,n,y,0.0508,W yr m-2 C Tg-1,IPCC AR6 radiative efficiency BC (7.
 forcing,rho_oc,n,n,y,-0.00621,W yr m-2 C Tg-1,IPCC AR6 radiative efficiency OC (7.SM.1.3.1 of IPCC AR6)
 forcing,rho_so2,n,n,y,-7.24E-06,W yr m-2 S Gg-1,IPCC AR6 radiative efficiency SO2 (7.SM.1.3.1 of IPCC AR6)
 forcing,rho_nh3,n,n,y,-0.00208,W yr m-2 NH3 Tg-1,IPCC AR6 radiative efficiency NH3 (7.SM.1.3.1 of IPCC AR6)
-forcing,rho_h2o_h2,n,n,y,0.00019,W m _2 H2 Tg_1,strat. H2O vapor forcing from H2 emissions (Sand et al. 2023)
+forcing,rho_h2o_h2,n,n,y,1.30E-04,W m _2 H2 Tg_1,"strat. H2O vapor forcing from H2 emissions without CH4 effects Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8"
 forcing,RF_misc,n,n,n,"""(csv)""",,Miscellaneous radiative forcings default set to 0
 forcing,aero_scalar,n,n,y,1,(unitless),Uncerainty scalar
 forcing,vol_scalar,n,n,y,1,(unitless),Uncerainty scalar

--- a/inst/input/hector_picontrol.ini
+++ b/inst/input/hector_picontrol.ini
@@ -130,7 +130,7 @@ CCH4=-0.32			; coefficient for CH4 (unitless) Wigley et al. 2002
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 					; preindustrial O3 concentration
-CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions[1745]=3.877282     ; emissions time series
 CO_emissions[1745]=348.5273588      ; emissions time series
 NMVOC_emissions[1745]= 60.02182622   ; emissions time series

--- a/inst/input/hector_ssp119.ini
+++ b/inst/input/hector_ssp119.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp119_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp119_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp119_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp126.ini
+++ b/inst/input/hector_ssp126.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp126_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp126_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp126_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp245.ini
+++ b/inst/input/hector_ssp245.ini
@@ -143,7 +143,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			    ; preindustrial O3 concentration
-CO3_H2=4.09e-3 			; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp245_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp245_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp245_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp370.ini
+++ b/inst/input/hector_ssp370.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023, 10.1038/s43247-023-00857-8
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp370_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp370_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp370_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp434.ini
+++ b/inst/input/hector_ssp434.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp434_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp434_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp434_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp460.ini
+++ b/inst/input/hector_ssp460.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp460_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp460_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp460_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp534-over.ini
+++ b/inst/input/hector_ssp534-over.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp534-over_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp534-over_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp534-over_emiss-constraints_rf.csv 	; emissions time series

--- a/inst/input/hector_ssp585.ini
+++ b/inst/input/hector_ssp585.ini
@@ -142,7 +142,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 			; preindustrial O3 concentration
-CO3_H2=4.09e-3 		; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:tables/ssp585_emiss-constraints_rf.csv  	; emissions time series
 CO_emissions=csv:tables/ssp585_emiss-constraints_rf.csv		; emissions time series
 NMVOC_emissions=csv:tables/ssp585_emiss-constraints_rf.csv 	; emissions time series

--- a/tests/testthat/input/luc_pulse.ini
+++ b/tests/testthat/input/luc_pulse.ini
@@ -122,7 +122,7 @@ H2_CCO=4.25         ; scaling factor for the CO coefficient that affects OH life
 ;------------------------------------------------------------------------
 [ozone]
 PO3=30.0 					; preindustrial O3 concentration
-CO3_H2=4.09e-3 			    ; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) SI Table 3 of Sand et al. 2023
+CO3_H2=4.09e-3 		       	; coefficient for H2 contribution to trop. O3 RF (DU O3 Tg H2-1) Sand et al. 2023 ST4, 10.1038/s43247-023-00857-8
 NOX_emissions=csv:luc_pulse_tables.csv  	; emissions time series
 CO_emissions=csv:luc_pulse_tables.csv		; emissions time series
 NMVOC_emissions=csv:luc_pulse_tables.csv 	; emissions time series


### PR DESCRIPTION
(1) Use the value from Sand et al. 2023 ST4 for the H2 emission coefficient for the strat. H2O water vapor forcing. This prevents double-counting forcing effects from CH4. 
(2) Use consistent formatting to cite the Sand et al. 2023 parameters used in hector. 