### PR TITLE
updating citation file for the zenodo release

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/new_release_checklist.md
@@ -10,8 +10,10 @@ Since the dev branch only includes materials that have been peer-reviewed at lea
 * Add text to the PR documenting the major model changes. The PR is going to serve as an important record 
 * Pass automated checks
 * Change the version number in the DESCRIPTION file 
+* Change the version number in the CITATION.cff file
 * Update the NEWS.md, are links additional materials necessary? Does the release need a new naming file? 
 * Check to make sure the internal package data is up to date (fxntable, inputstable, unitstable)
+
 
 After merging PR 
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 3.0.1
+cff-version: 3.5.0
 message: "If you use this software in your work, please cite it as below."
 authors:
 - family-names: "Dorheim"
@@ -7,6 +7,9 @@ authors:
 - family-names: "Bond-Lamberty"
   given-names: "Ben"
   orcid: "https://orcid.org/0000-0001-9525-4633"
+- family-names: "Scully"
+  given-names: "Peter"
+  orcid: "https://orcid.org/0009-0007-0234-0366"
 - family-names: "Hartin"
   given-names: "Corinne"
   orcid: "https://orcid.org/0000-0003-1834-6539"
@@ -31,7 +34,7 @@ authors:
   given-names: "Dawn"
   orcid: "https://orcid.org/0000-0002-0468-4660"
 title: "Hector a simple carbon-climate model"
-version: 3.0.1
-doi: 10.5281/zenodo.7617326
-date-released: 2023-02-07
+version: 3.5.0
+doi: 10.5281/zenodo.821645
+date-released: 2025-10-24
 url: "https://github.com/jgcri/hector"


### PR DESCRIPTION
Update the citation file for the zeondo release and adding a note to the release check list to make sure this step is not skipped next time. 