### PR TITLE
RH CH4 bug fix

### DIFF
--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -175,7 +175,7 @@ void CSVOutputStreamVisitor::visit(SimpleNbox *c) {
   STREAM_UNITVAL(csvFile, c, D_RH, c->final_rh[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH_DETRITUS, c->final_rh_detritus[SNBOX_DEFAULT_BIOME]);
   STREAM_UNITVAL(csvFile, c, D_RH_SOIL, c->final_rh_soil[SNBOX_DEFAULT_BIOME]);
-  STREAM_UNITVAL(csvFile, c, D_RH_CH4, c->final_rh[SNBOX_DEFAULT_BIOME]);
+  STREAM_UNITVAL(csvFile, c, D_RH_CH4, c->RH_ch4[SNBOX_DEFAULT_BIOME]);
   STREAM_MESSAGE_DATE(csvFile, c, D_CO2_CONC, current_date);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_CO2);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_C_RESIDUAL);


### PR DESCRIPTION
This is a bug fix that addresses/answers the two issues identified by Raines Lucas in #795. Previously the csv output visitor was returning rh instead of rh_ch4.

Now the rh_ch4 results are 0 when permafrost is turned off. 

<img width="563" height="449" alt="image" src="https://github.com/user-attachments/assets/81dae59c-e24b-4086-83c8-fda923c8dc37" />

There was also a question of whether the units were correct, and yes, the rh_ch4 variable should be PgC. 