### PR TITLE
Output stream visitor bug fix

### DIFF
--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -74,6 +74,7 @@ CSVOutputStreamVisitor::CSVOutputStreamVisitor(ostream &outputStream,
   current_date = 0;
   datestring = "";
   spinupstring = "";
+  csvFile.precision(15);
 }
 
 //------------------------------------------------------------------------------
@@ -134,7 +135,6 @@ void CSVOutputStreamVisitor::visit(Core *c) {
 void CSVOutputStreamVisitor::visit(ForcingComponent *c) {
   if (!core->outputEnabled(c->getComponentName()))
     return;
-   csvFile.precision(15);
 
   if (c->currentYear < c->baseyear)
     return;

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -109,18 +109,6 @@ void CSVOutputStreamVisitor::visit(Core *c) {
   core = c;
 }
 
-// TODO: consolidate these macros into the two MESSAGE ones,
-// and shift string literals to D_xxxx definitions
-
-// Macro to send a variable with associated unitval units to some output stream
-// Takes s (stream), c (component), xname (variable name), x (output variable)
-#define STREAM_UNITVAL(s, c, xname, x)                                         \
-  {                                                                            \
-    s << linestamp() << c->getComponentName() << DELIMITER << xname            \
-      << DELIMITER << x.value(x.units()) << DELIMITER << x.unitsName()         \
-      << std::endl;                                                            \
-  }
-
 // Macro to send a variable with associated unitval units to some output stream
 // This uses new sendMessage interface in imodel_component
 // Takes s (stream), c (component), xname (variable name)
@@ -155,7 +143,7 @@ void CSVOutputStreamVisitor::visit(ForcingComponent *c) {
 
   // Walk through the forcings map, outputting everything
   for (auto f : forcings) {
-    STREAM_UNITVAL(csvFile, c, f.first, f.second);
+      STREAM_MESSAGE_DATE(csvFile, c, f.first, current_date);
   }
 
 }
@@ -170,11 +158,11 @@ void CSVOutputStreamVisitor::visit(SimpleNbox *c) {
   // Note if there are multiple biomes, these values will be totals, summed
   // across all biomes
   STREAM_MESSAGE(csvFile, c, D_NBP);
-  STREAM_UNITVAL(csvFile, c, D_NPP, c->final_npp[SNBOX_DEFAULT_BIOME]);
-  STREAM_UNITVAL(csvFile, c, D_RH, c->final_rh[SNBOX_DEFAULT_BIOME]);
-  STREAM_UNITVAL(csvFile, c, D_RH_DETRITUS, c->final_rh_detritus[SNBOX_DEFAULT_BIOME]);
-  STREAM_UNITVAL(csvFile, c, D_RH_SOIL, c->final_rh_soil[SNBOX_DEFAULT_BIOME]);
-  STREAM_UNITVAL(csvFile, c, D_RH_CH4, c->RH_ch4[SNBOX_DEFAULT_BIOME]);
+  STREAM_MESSAGE(csvFile, c, D_NPP);
+  STREAM_MESSAGE(csvFile, c, D_RH);
+  STREAM_MESSAGE(csvFile, c, D_RH_DETRITUS);
+  STREAM_MESSAGE(csvFile, c, D_RH_SOIL);
+  STREAM_MESSAGE(csvFile, c, D_RH_CH4);
   STREAM_MESSAGE_DATE(csvFile, c, D_CO2_CONC, current_date);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_CO2);
   STREAM_MESSAGE(csvFile, c, D_ATMOSPHERIC_C_RESIDUAL);
@@ -191,28 +179,17 @@ void CSVOutputStreamVisitor::visit(SimpleNbox *c) {
     SimpleNbox::fluxpool_stringmap::const_iterator it;
     for (auto b : c->veg_c) {
       std::string biome = b.first;
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_NPP,
-                     c->final_npp[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_RH,
-                     c->final_rh[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_RH_CH4,
-                     c->RH_ch4[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_VEGC,
-                     c->veg_c[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_DETRITUSC,
-                     c->detritus_c[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_SOILC,
-                     c->soil_c[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_PERMAFROSTC,
-                     c->permafrost_c[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_THAWEDPC,
-                     c->thawed_permafrost_c[biome]);
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_F_FROZEN,
-                     unitval(c->f_frozen[biome], U_UNITLESS));
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTD,
-                     unitval(c->tempfertd[biome], U_UNITLESS));
-      STREAM_UNITVAL(csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTS,
-                     unitval(c->tempferts[biome], U_UNITLESS));
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_NPP);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_RH);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_RH_CH4);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_VEGC);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_DETRITUSC);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_SOILC);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_PERMAFROSTC);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_THAWEDPC);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_F_FROZEN);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTD);
+      STREAM_MESSAGE(csvFile, c, biome + SNBOX_PARSECHAR + D_TEMPFERTS);
     }
   }
 }

--- a/src/csv_outputstream_visitor.cpp
+++ b/src/csv_outputstream_visitor.cpp
@@ -146,7 +146,7 @@ void CSVOutputStreamVisitor::visit(Core *c) {
 void CSVOutputStreamVisitor::visit(ForcingComponent *c) {
   if (!core->outputEnabled(c->getComponentName()))
     return;
-  streamsize oldPrecision = csvFile.precision(4);
+   csvFile.precision(15);
 
   if (c->currentYear < c->baseyear)
     return;
@@ -158,7 +158,6 @@ void CSVOutputStreamVisitor::visit(ForcingComponent *c) {
     STREAM_UNITVAL(csvFile, c, f.first, f.second);
   }
 
-  csvFile.precision(oldPrecision);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION

This PR addresses a rounding issue that is only relevant to the CSV output stream & addresses an inline TODO item related to the csvouput stream visitor.  


**The Problem**

While working on #795, I realized that there were some numerical differences between Hector results written out by the CSV output stream visitor vs. fetched via R. 

When we compare the numerical results from hector output via R vs. csv outputter the overall summary table absolute error (this is across multiple scenarios & variables)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-9b9aba8f-7fff-7154-39c4-bb1668ae7c2a"><div dir="ltr" style="margin-left:0pt;" align="center">
Min | 1 IQR | Median | Mean | 3 IQR | Max
-- | -- | -- | -- | -- | --
0 | 0 | 0.000018 | 0.081499 | 0.003465 | 4.999791

</div><br /><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;" </span></p></b><br class="Apple-interchange-newline">

Of the 80 variables considered 57 of them had a MAE &gt; 1E-6 

Looking at the variable with the largest error, DO ocean C, while the relative MAE of 4.999791. A visual comparison of  DO ocean C reveals a step like behavior in the csv result which seems odd and is most likely due to rounding. 

<img width="827" height="486" alt="Screenshot 2025-12-31 at 8 48 53 AM" src="https://github.com/user-attachments/assets/cf125316-fe94-4575-adeb-59c56ae6ad7f" />

Same data but different perspective. 

<img width="611" height="561" alt="Screenshot 2025-12-31 at 8 50 07 AM" src="https://github.com/user-attachments/assets/00b5816d-4f7f-40c6-9c94-a5e5a6a3c5e4" />


**the solution** 

It turns out the csvFile has a default precision level of 6 whereas typical C++ double precision is 16. Since R was pulling directly from the C++ precision level we needed to make sure that the csvFile was using the same precision level. 

After changing the precision level of the csvFile the MAE between R and the csv output the MAE is now 1.035752e-13. Which is much better! And now no longer see the step behavior we were seeing before. 


<img width="782" height="538" alt="Screenshot 2025-12-31 at 8 52 57 AM" src="https://github.com/user-attachments/assets/aa6bce0c-715d-49e5-b7c1-647eb718cb36" />








