### PR TITLE
use explicit csv parser when reading in input table header

### DIFF
--- a/inst/include/csv_table_reader.hpp
+++ b/inst/include/csv_table_reader.hpp
@@ -56,8 +56,11 @@ private:
   //! Current line (that has just been read)
   int lineNum;
 
-  // Helper function to find next non-commented line
+  //! Helper function to find next non-commented line
   std::string csv_getline();
+    
+  //! Helper function that reads the header row and returns all column names as a vector
+  std::vector<std::string> read_header();
 };
 
 } // namespace Hector

--- a/src/csv_table_reader.cpp
+++ b/src/csv_table_reader.cpp
@@ -22,6 +22,7 @@
 #pragma clang diagnostic pop
 
 #include <boost/algorithm/string/split.hpp>
+#include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <errno.h>
 
@@ -32,6 +33,8 @@
 namespace Hector {
 
 using namespace std;
+using CsvTok = boost::tokenizer<boost::escaped_list_separator<char>>;
+
 
 //------------------------------------------------------------------------------
 /*! \brief Constructor
@@ -92,6 +95,33 @@ string CSVTableReader::csv_getline() {
 }
 
 //------------------------------------------------------------------------------
+/*! \brief Helper function
+ *
+ *  Read in and format the header of a hector input csv table.
+ */
+std::vector<std::string> Hector::CSVTableReader::read_header() {
+    using namespace boost;
+
+    // Skip all the comments at the start of the hector CSV input table
+    std::string line = csv_getline();
+    H_ASSERT(!line.empty(), "Header line is empty");
+
+    // Parse variable names from the CSV
+    std::vector<std::string> headerRow;
+    CsvTok tok(line);
+    headerRow.assign(tok.begin(), tok.end());
+
+    // Tim any whitespace included in the header
+    for (auto& colName : headerRow) {
+        trim(colName);
+    }
+
+    return headerRow;
+}
+
+
+
+//------------------------------------------------------------------------------
 /*! \brief Process the CSV file looking for the given varName and route the data
  *         into the core.
  *
@@ -129,21 +159,18 @@ void CSVTableReader::process(Core *core, const string &componentName,
 
     // read the header line and attempt to find varName. The first column is
     // not considered because that should be the index column.
-    line = csv_getline();
-    H_ASSERT(!line.empty(), "line empty");
-    split(row, line, is_any_of(","));
-    //        const int headerRowSize = row.size();
-    for (size_t col = 1; col < row.size() && columnIndex == 0; ++col) {
-      // ignore white space before comparing variable names
-      trim(row[col]);
-      if (row[col] == varName) {
-        columnIndex = col;
+    row = read_header();
+      
+    for (size_t col = 1; col < row.size(); ++col) {
+          if (row[col] == varName) {
+              columnIndex = col;
+              break;
+          }
       }
-    }
-    if (columnIndex == 0) {
-      H_THROW("Could not find a column for " + varName + " in " + fileName +
-              " header=" + line);
-    }
+      if (columnIndex == 0) {
+          H_THROW("Could not find a column for " + varName +
+                  " in " + fileName);
+      }
 
     // we are all set to process the table
     // note that getline sets the fail bit when it hits eof which is not what


### PR DESCRIPTION
Both Brian and myself had been running into issues where the csv reader was sensitive to how the hector csv input table was created. We were running into this error 

```
Mon Feb  2 12:35:53 2026:NOTICE:main: Setting data in the core.
* Program exception:
msg:  	Could not find a column for CH3Br_constrain in /Users/dorh012/Documents/2026/RCMIPIII/hector-rcmip3/input/tables/1pctCO2.csv header="Date","CH4_constrain","CO2_constrain","HFC227ea_constrain","HFC32_constrain","C2F6_constrain","CF4_constrain","CCl4_constrain","CH3Br_constrain","CH3Cl_constrain","halon1211_constrain","N2O_constrain","ffi_emissions","daccs_uptake","luc_emissions","luc_uptake","RF_albedo","SO2_emissions","SV","CH4N","CH4_emissions","NOX_emissions","CO_emissions","NMVOC_emissions","N2O_natural_emissions","N2O_emissions","RF_misc","BC_emissions","OC_emissions","NH3_emissions","CF4_emissions","C2F6_emissions","HFC23_emissions","HFC32_emissions","HFC4310_emissions","HFC125_emissions","HFC134a_emissions","HFC143a_emissions","HFC227ea_emissions","HFC245fa_emissions","SF6_emissions","CFC11_emissions","CFC12_emissions","CFC113_emissions","CFC114_emissions","CFC115_emissions","CCl4_emissions","CH3CCl3_emissions","halon1211_emissions","halon1301_emissions","halon2402_emissions","HCFC22_emissions","HCFC141b_emissions","HCFC142b_emissions","CH3Cl_emissions","CH3Br_emissions"
func: 	process
file: 	csv_table_reader.cpp
ffile:	/Users/dorh012/Documents/Hector-WD/hector/src/csv_table_reader.cpp

line: 	145
```

even though the missing column was included in the input table. It turns out that depending on the program(s) used to generate and edit the csv input table `""` would be included in the header row which contained strings. Hector's CSVTableReader could handle white space but not the `"`. '


Here we address that by using a boost-supported CSV parsing, which handles this better. 